### PR TITLE
Fix 500 error in async auth token request

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
   <name>FHIR Bulk Client</name>
   <description>Java client library for FHIR Bulk Export.</description>
   <url>https://github.com/aehrc/fhir-bulk-java</url>
-  
+
   <developers>
     <developer>
       <name>John Grimes</name>
@@ -207,6 +207,12 @@
       <artifactId>logback-classic</artifactId>
       <scope>test</scope>
     </dependency>
+    <!-- required to enable httpclient logging -->
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>jcl-over-slf4j</artifactId>
+      <scope>test</scope>
+    </dependency>
     <!-- hadoop client runtime for testing -->
     <dependency>
       <groupId>org.apache.hadoop</groupId>
@@ -310,6 +316,11 @@
         <groupId>ch.qos.logback</groupId>
         <artifactId>logback-core</artifactId>
         <version>${bulkExport.logbackVersion}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.slf4j</groupId>
+        <artifactId>jcl-over-slf4j</artifactId>
+        <version>${bulkExport.slf4jVersion}</version>
       </dependency>
       <dependency>
         <groupId>org.junit.jupiter</groupId>

--- a/src/main/java/au/csiro/fhir/auth/ClientAuthMethod.java
+++ b/src/main/java/au/csiro/fhir/auth/ClientAuthMethod.java
@@ -201,6 +201,7 @@ public abstract class ClientAuthMethod {
     final HttpPost request = new HttpPost(getTokenEndpoint());
     request.addHeader(HttpHeaders.ACCEPT, "application/json");
     request.addHeader(HttpHeaders.CACHE_CONTROL, "no-cache");
+    request.addHeader(HttpHeaders.CONTENT_TYPE, "application/x-www-form-urlencoded");
     getAuthHeaders().forEach(request::addHeader);
 
     final List<NameValuePair> params = new ArrayList<>();

--- a/src/main/java/au/csiro/fhir/auth/ClientAuthMethod.java
+++ b/src/main/java/au/csiro/fhir/auth/ClientAuthMethod.java
@@ -20,6 +20,7 @@ package au.csiro.fhir.auth;
 import static java.util.Objects.nonNull;
 import static java.util.Objects.requireNonNull;
 
+import au.csiro.http.JsonResponseHandler;
 import java.io.IOException;
 import java.time.Instant;
 import java.util.ArrayList;
@@ -27,9 +28,9 @@ import java.util.Collections;
 import java.util.List;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import au.csiro.http.JsonResponseHandler;
 import lombok.Value;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.http.Consts;
 import org.apache.http.Header;
 import org.apache.http.HttpHeaders;
 import org.apache.http.NameValuePair;
@@ -39,7 +40,6 @@ import org.apache.http.client.entity.UrlEncodedFormEntity;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.client.methods.HttpUriRequest;
 import org.apache.http.message.BasicNameValuePair;
-import org.apache.http.protocol.HTTP;
 
 /**
  * Authentication method for one of the FHIR SMART client authentication profiles.
@@ -201,7 +201,6 @@ public abstract class ClientAuthMethod {
     final HttpPost request = new HttpPost(getTokenEndpoint());
     request.addHeader(HttpHeaders.ACCEPT, "application/json");
     request.addHeader(HttpHeaders.CACHE_CONTROL, "no-cache");
-    request.addHeader(HttpHeaders.CONTENT_TYPE, "application/x-www-form-urlencoded");
     getAuthHeaders().forEach(request::addHeader);
 
     final List<NameValuePair> params = new ArrayList<>();
@@ -211,7 +210,7 @@ public abstract class ClientAuthMethod {
       params.add(new BasicNameValuePair(PARAM_SCOPE, getScope()));
     }
     params.addAll(getAuthParams());
-    request.setEntity(new UrlEncodedFormEntity(params, HTTP.DEF_CONTENT_CHARSET));
+    request.setEntity(new UrlEncodedFormEntity(params, Consts.UTF_8));
     return request;
   }
 

--- a/src/test/resources/logback.xml
+++ b/src/test/resources/logback.xml
@@ -32,6 +32,7 @@
     <appender-ref ref="TIMING"/>
   </logger>
   <logger level="DEBUG" name="au.csiro"/>
+  <!-- set to DEBUG to enable logging of HTTP client wire data -->
   <logger level="ERROR" name="org.apache.http.wire"/>
   <root level="WARN">
     <appender-ref ref="STDOUT"/>


### PR DESCRIPTION
This was causing a 500 error when requesting a token from the SMART Bulk Data test server.