### PR TITLE
Add _until parameter support

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,9 @@ Supported features:
 
 - Fluent Java API for configuring and running the export
 - System, group and patient level export
-- All Bulk Data v2 [query parameters](https://hl7.org/fhir/uv/bulkdata/export.html#query-parameters) 
+- Bulk Data v2 [query parameters](https://hl7.org/fhir/uv/bulkdata/export.html#query-parameters)
   (with some limitations for patient references)
+- Bulk Data v3 `_until` query parameter
 - Asymmetric and
   symmetric [SMART authentication profiles](https://www.hl7.org/fhir/smart-app-launch/client-authentication.html)
 - Automatic token endpoint discovery with SMART configuration discovery
@@ -132,6 +133,7 @@ final BulkExportResult result = BulkExportClient.groupBuilder("BMCHealthNet")
         .withOutputDir(outputDir)
         .withOutputFormat("ndjson")
         .withSince(Instant.parse("2015-01-01T00:00:00.000Z"))
+        .withUntil(Instant.parse("2024-01-01T00:00:00.000Z"))
         .withTypes(List.of("Patient", "Condition"))
         .withType("Observation")
         .withElements(List.of("id", "status"))

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
   <modelVersion>4.0.0</modelVersion>
 
   <groupId>au.csiro.fhir</groupId>
-  <version>1.0.3</version>
+  <version>1.0.4-SNAPSHOT</version>
   <artifactId>bulk-export</artifactId>
   <packaging>jar</packaging>
 

--- a/src/main/java/au/csiro/fhir/export/BulkExportClient.java
+++ b/src/main/java/au/csiro/fhir/export/BulkExportClient.java
@@ -118,6 +118,14 @@ public class BulkExportClient {
   Instant since = null;
 
   /**
+   * The time to end the export at. If null, the server's current time is used. The value of the
+   * `_until` parameter in the export request.
+   */
+  @Nullable
+  @Builder.Default
+  Instant until = null;
+
+  /**
    * The types of resources to export. The value of the `_type` parameter in the export request.
    */
   @Nonnull
@@ -355,6 +363,7 @@ public class BulkExportClient {
         ._outputFormat(outputFormat)
         ._type(types)
         ._since(since)
+        ._until(until)
         ._elements(elements)
         ._typeFilter(typeFilters)
         .includeAssociatedData(includeAssociatedData)

--- a/src/main/java/au/csiro/fhir/export/ws/BulkExportRequest.java
+++ b/src/main/java/au/csiro/fhir/export/ws/BulkExportRequest.java
@@ -150,10 +150,19 @@ public class BulkExportRequest {
 
   /**
    * The date and time to use as the lower bound for the export. The value of the '_since' query
+   * parameter.
    */
   @Nullable
   @Builder.Default
   Instant _since = null;
+
+  /**
+   * The date and time to use as the upper bound for the export. The value of the '_until' query
+   * parameter.
+   */
+  @Nullable
+  @Builder.Default
+  Instant _until = null;
 
   /**
    * The types of resources to export. The value of the '_type' query parameter.
@@ -208,6 +217,8 @@ public class BulkExportRequest {
                 .map(s -> Parameter.of("_outputFormat", s)).stream(),
             Optional.ofNullable(_since)
                 .map(s -> Parameter.of("_since", s)).stream(),
+            Optional.ofNullable(_until)
+                .map(u -> Parameter.of("_until", u)).stream(),
             optionalOfList(_type)
                 .map(e -> Parameter.of("_type", String.join(",", e))).stream(),
             optionalOfList(_elements)
@@ -241,6 +252,10 @@ public class BulkExportRequest {
     if (get_since() != null) {
       uriBuilder.addParameter("_since",
           FhirFormats.formatFhirInstant(Objects.requireNonNull(get_since())));
+    }
+    if (get_until() != null) {
+      uriBuilder.addParameter("_until",
+          FhirFormats.formatFhirInstant(Objects.requireNonNull(get_until())));
     }
     if (!get_type().isEmpty()) {
       uriBuilder.addParameter("_type", String.join(",", get_type()));

--- a/src/test/java/au/csiro/fhir/export/BulkExportClientWiremockTest.java
+++ b/src/test/java/au/csiro/fhir/export/BulkExportClientWiremockTest.java
@@ -707,14 +707,14 @@ class BulkExportClientWiremockTest {
 
     stubFor(get(urlPathEqualTo("/file/00"))
         .willReturn(aResponse()
-            .withFixedDelay(2_000)
+            .withFixedDelay(10_000)
             .withStatus(200)
             .withBody(RESOURCE_00))
     );
 
     stubFor(get(urlPathEqualTo("/file/01"))
         .willReturn(aResponse()
-            .withFixedDelay(2_000)
+            .withFixedDelay(10_000)
             .withStatus(200)
             .withBody(RESOURCE_01))
     );
@@ -736,7 +736,7 @@ class BulkExportClientWiremockTest {
             BulkExportClient.builder()
                 .withFhirEndpointUrl(bulkExportDemoServerEndpoint)
                 .withOutputDir(exportDir.getPath())
-                .withTimeout(Duration.ofSeconds(3))
+                .withTimeout(Duration.ofSeconds(5))
                 .build()
                 .export()
     );

--- a/src/test/java/au/csiro/fhir/export/ws/BulkExportRequestTest.java
+++ b/src/test/java/au/csiro/fhir/export/ws/BulkExportRequestTest.java
@@ -49,6 +49,7 @@ class BulkExportRequestTest {
     final BulkExportRequest request = BulkExportRequest.builder()
         ._outputFormat("fhir+ndjson")
         ._since(Instant.parse("2023-08-01T00:00:00Z"))
+        ._until(Instant.parse("2023-12-31T23:59:59Z"))
         ._type(List.of("Patient", "Condition"))
         ._elements(List.of("Patient.name", "Patient.birthDate"))
         ._typeFilter(List.of("Patient?active=true", "Condition?clinicalStatus=active"))
@@ -60,12 +61,26 @@ class BulkExportRequestTest {
         Parameters.of(
             Parameter.of("_outputFormat", "fhir+ndjson"),
             Parameter.of("_since", Instant.parse("2023-08-01T00:00:00Z")),
+            Parameter.of("_until", Instant.parse("2023-12-31T23:59:59Z")),
             Parameter.of("_type", "Patient,Condition"),
             Parameter.of("_elements", "Patient.name,Patient.birthDate"),
             Parameter.of("_typeFilter", "Patient?active=true,Condition?clinicalStatus=active"),
             Parameter.of("includeAssociatedData", "LatestProvenanceResources,_customXXX"),
             Parameter.of("patient", Reference.of("Patient/00")),
             Parameter.of("patient", Reference.of("Patient/01"))
+        ),
+        request.toParameters());
+  }
+
+  @Test
+  void testToParametersWithOnlyUntil() {
+    // Test that _until can be used independently of _since.
+    final BulkExportRequest request = BulkExportRequest.builder()
+        ._until(Instant.parse("2024-06-15T12:00:00.500Z"))
+        .build();
+    assertEquals(
+        Parameters.of(
+            Parameter.of("_until", Instant.parse("2024-06-15T12:00:00.500Z"))
         ),
         request.toParameters());
   }
@@ -81,10 +96,12 @@ class BulkExportRequestTest {
   @Test
   void testNonDefaultRequestUri() {
     final URI baseUri = URI.create("http://test.com/fhir");
-    final Instant testInstant = Instant.parse("2023-01-11T00:00:00.1234Z");
+    final Instant sinceInstant = Instant.parse("2023-01-11T00:00:00.1234Z");
+    final Instant untilInstant = Instant.parse("2023-12-31T23:59:59.9876Z");
     assertEquals(URI.create(
             "http://test.com/fhir?_outputFormat=xml"
                 + "&_since=2023-01-11T00%3A00%3A00.123Z"
+                + "&_until=2023-12-31T23%3A59%3A59.987Z"
                 + "&_type=Patient%2CObservation"
                 + "&_elements=Patient.id%2CCondition.status"
                 + "&_typeFilter=Patient.active%3Dtrue%2CObservation.status%3Dfinal"
@@ -94,9 +111,23 @@ class BulkExportRequestTest {
             ._type(List.of("Patient", "Observation"))
             ._elements(List.of("Patient.id", "Condition.status"))
             ._typeFilter(List.of("Patient.active=true", "Observation.status=final"))
-            ._since(testInstant)
+            ._since(sinceInstant)
+            ._until(untilInstant)
             .includeAssociatedData(List.of(AssociatedData.RELEVANT_PROVENANCE_RESOURCES,
                 AssociatedData.custom("customYYY")))
+            .build().toRequestURI(baseUri)
+    );
+  }
+
+  @Test
+  void testRequestUriWithOnlyUntil() {
+    // Test that _until can be used independently in URI without _since.
+    final URI baseUri = URI.create("http://test.com/fhir");
+    final Instant untilInstant = Instant.parse("2024-06-15T12:00:00.500Z");
+    assertEquals(URI.create(
+            "http://test.com/fhir?_until=2024-06-15T12%3A00%3A00.500Z"),
+        BulkExportRequest.builder()
+            ._until(untilInstant)
             .build().toRequestURI(baseUri)
     );
   }
@@ -118,13 +149,15 @@ class BulkExportRequestTest {
 
   @Test
   void testCreatesAllValuesSystemExportRequest() {
-    final Instant testInstant = Instant.parse("2023-01-11T00:00:00.1234Z");
+    final Instant sinceInstant = Instant.parse("2023-01-11T00:00:00.1234Z");
+    final Instant untilInstant = Instant.parse("2023-12-31T23:59:59.9876Z");
     final BulkExportRequest request = BulkExportRequest.builder()
         ._outputFormat("xml")
         ._type(List.of("Patient", "Observation"))
         ._elements(List.of("Patient.id", "Condition.status"))
         ._typeFilter(List.of("Patient.active=true", "Observation.status=final"))
-        ._since(testInstant)
+        ._since(sinceInstant)
+        ._until(untilInstant)
         .includeAssociatedData(List.of(AssociatedData.LATEST_PROVENANCE_RESOURCES,
             AssociatedData.custom("customZZZ")))
         .build();
@@ -132,6 +165,7 @@ class BulkExportRequestTest {
     assertEquals("GET", httpRequest.getMethod());
     assertEquals("http://test.com/fhir/$export?_outputFormat=xml"
             + "&_since=2023-01-11T00%3A00%3A00.123Z"
+            + "&_until=2023-12-31T23%3A59%3A59.987Z"
             + "&_type=Patient%2CObservation"
             + "&_elements=Patient.id%2CCondition.status"
             + "&_typeFilter=Patient.active%3Dtrue%2CObservation.status%3Dfinal"
@@ -219,6 +253,7 @@ class BulkExportRequestTest {
         .level(new GroupLevel("id0001"))
         ._outputFormat("fhir+ndjson")
         ._since(Instant.parse("2023-08-01T00:00:00Z"))
+        ._until(Instant.parse("2023-12-31T23:59:59Z"))
         ._type(List.of("Patient", "Condition"))
         ._elements(List.of("Patient.name", "Patient.birthDate"))
         ._typeFilter(List.of("Patient?active=true", "Condition?clinicalStatus=active"))
@@ -241,6 +276,7 @@ class BulkExportRequestTest {
         Parameters.of(
             Parameter.of("_outputFormat", "fhir+ndjson"),
             Parameter.of("_since", Instant.parse("2023-08-01T00:00:00Z")),
+            Parameter.of("_until", Instant.parse("2023-12-31T23:59:59Z")),
             Parameter.of("_type", "Patient,Condition"),
             Parameter.of("_elements", "Patient.name,Patient.birthDate"),
             Parameter.of("_typeFilter", "Patient?active=true,Condition?clinicalStatus=active"),


### PR DESCRIPTION
Implements the `_until` query parameter as specified in the [Bulk Data Access v3 specification](https://hl7.org/fhir/uv/bulkdata/export.html#query-parameters). This parameter filters resources to include only those modified before a specified timestamp, complementing the existing `_since` parameter.

## Changes

- Add `_until` field to `BulkExportRequest` with serialisation for GET (URL) and POST (Parameters body) requests
- Add `until` field to `BulkExportClient` builder
- Update README with v3 feature documentation and usage example
- Fix flaky `testExportFailsTimeOutInDownload` test by adjusting timing margins