### PR TITLE
Stop closing a shared Hadoop filesystem

### DIFF
--- a/src/main/java/au/csiro/filestore/hdfs/HdfsFileStoreFactory.java
+++ b/src/main/java/au/csiro/filestore/hdfs/HdfsFileStoreFactory.java
@@ -33,15 +33,27 @@ import org.apache.hadoop.fs.Path;
 /**
  * File store factory based on Apache Hadoop HDFS FileSystem.
  *
- * <p>Filesystems are resolved through the JVM-wide Hadoop filesystem cache and are borrowed rather
- * than owned, so closing a store never closes the filesystem behind it. Releasing cached instances
- * is the host application's business; Hadoop closes what remains at JVM shutdown.
+ * <p>Unless a filesystem is supplied explicitly through {@link #forFileSystem(FileSystem)},
+ * filesystems are resolved with {@link FileSystem#get(URI, Configuration)}, which returns an
+ * instance from the JVM-wide Hadoop filesystem cache that this library shares with the rest of the
+ * host application. Either way the filesystem is borrowed rather than owned, so closing a store
+ * never closes the filesystem behind it. Releasing instances is the host application's business;
+ * Hadoop closes whatever remains in the cache at JVM shutdown, unless the application has turned
+ * that off by setting {@code fs.automatic.close} to false.
  *
  * <p>That obligation becomes a real one in a server that impersonates its users. The cache is keyed
  * on scheme, authority and user, so each distinct user reaching a destination creates an instance
  * that lives until the JVM exits. A server using {@code UserGroupInformation.doAs} should call
  * {@code FileSystem.closeAllForUGI} when it tears a user's session down, or instances will
  * accumulate for as long as the process runs.
+ *
+ * <p>As with {@link FileSystem#get(URI, Configuration)}, the configuration held by this factory is
+ * respected only on a cache miss. Because the key is scheme, authority and user alone, a
+ * destination the host application has already opened resolves to that existing instance and the
+ * configuration is ignored entirely. It takes effect only where the cache has to construct
+ * something, which is why {@link #HdfsFileStoreFactory(Configuration)} should be given the
+ * configuration the application itself uses, rather than relying on
+ * {@link #HdfsFileStoreFactory()}.
  */
 public class HdfsFileStoreFactory implements FileStoreFactory {
 
@@ -51,9 +63,12 @@ public class HdfsFileStoreFactory implements FileStoreFactory {
   /**
    * Creates a factory that resolves filesystems through the Hadoop filesystem cache.
    *
-   * <p>The configuration is only consulted when the cache has to construct a filesystem. The cache
-   * is keyed on scheme, authority and user alone, so if the host application has already opened a
-   * filesystem for the destination, that instance is returned and this configuration is ignored.
+   * <p>Pass the configuration the host application already holds — under Spark, the Hadoop
+   * configuration carrying its {@code spark.hadoop.*} settings — rather than a freshly
+   * constructed one. It is consulted only when the cache has to build a filesystem, but that is
+   * precisely when getting it wrong matters, because what gets built is then cached under the
+   * destination's key and handed to everything that asks for it afterwards, the host application
+   * included.
    *
    * @param configuration the configuration to construct filesystems from, on a cache miss
    */
@@ -63,7 +78,18 @@ public class HdfsFileStoreFactory implements FileStoreFactory {
 
   /**
    * Creates a factory that resolves filesystems through the Hadoop filesystem cache, using a
-   * default configuration when the cache has to construct one.
+   * default {@link Configuration} where the cache has to construct one.
+   *
+   * <p>A default configuration sees only what is on the classpath, in {@code core-site.xml} and its
+   * companions. It sees nothing the host application has configured programmatically, so on a cache
+   * miss for a destination such as {@code s3a://} the filesystem is built without the application's
+   * credentials, endpoint or region, and will usually fail to authenticate. The failure also
+   * outlives this export: the misconfigured instance is left in the JVM-wide cache under the
+   * destination's key, and the host application resolves that same instance from then on.
+   *
+   * <p>Prefer {@link #HdfsFileStoreFactory(Configuration)}. This constructor is only appropriate
+   * where the classpath configuration is genuinely complete, such as a standalone command line
+   * invocation, or where the destination filesystem is known to be open already.
    */
   public HdfsFileStoreFactory() {
     this(new Configuration());
@@ -74,17 +100,21 @@ public class HdfsFileStoreFactory implements FileStoreFactory {
    *
    * <p>Use this when the calling application holds a filesystem that the Hadoop cache will not
    * return for the destination, such as a decorated instance or one opened under a different user.
+   * The supplied filesystem is borrowed on the same terms as a cached one: the stores never close
+   * it, and it remains the caller's to release.
    *
-   * <p>The stores this factory creates ignore the location passed to
-   * {@link #createFileStore(String)} and route every operation through the supplied filesystem. A
-   * location belonging to a different filesystem fails with Hadoop's "Wrong FS" error.
+   * <p>The stores this factory creates ignore the location they are asked for and route every
+   * operation through the supplied filesystem. A location naming a different filesystem fails with
+   * Hadoop's "Wrong FS" error, but only where it names one: a location with no scheme is resolved
+   * against the supplied filesystem without complaint, whatever was intended.
    *
    * <p>Note that the supplied filesystem also fixes the identity that writes are performed as, in
    * place of the one the cache would have selected. A Hadoop filesystem captures its user when it
    * is constructed and keeps it for every later operation, so a server that impersonates its users
    * through {@code UserGroupInformation.doAs} loses that attribution here: every export writes as
    * whichever user opened the supplied instance, whoever requested it. This fails silently, so
-   * prefer {@link #createFileStore(String)} where per-user attribution matters.
+   * prefer a factory built with {@link #HdfsFileStoreFactory(Configuration)} where per-user
+   * attribution matters, and let the cache select the filesystem per user.
    *
    * @param fileSystem the filesystem to write through
    * @return a factory that creates stores over the supplied filesystem

--- a/src/main/java/au/csiro/filestore/hdfs/HdfsFileStoreFactory.java
+++ b/src/main/java/au/csiro/filestore/hdfs/HdfsFileStoreFactory.java
@@ -69,6 +69,31 @@ public class HdfsFileStoreFactory implements FileStoreFactory {
     this(new Configuration());
   }
 
+  /**
+   * Creates a factory that hands out stores over a filesystem supplied by the caller.
+   *
+   * <p>Use this when the calling application holds a filesystem that the Hadoop cache will not
+   * return for the destination, such as a decorated instance or one opened under a different user.
+   *
+   * <p>The stores this factory creates ignore the location passed to
+   * {@link #createFileStore(String)} and route every operation through the supplied filesystem. A
+   * location belonging to a different filesystem fails with Hadoop's "Wrong FS" error.
+   *
+   * <p>Note that the supplied filesystem also fixes the identity that writes are performed as, in
+   * place of the one the cache would have selected. A Hadoop filesystem captures its user when it
+   * is constructed and keeps it for every later operation, so a server that impersonates its users
+   * through {@code UserGroupInformation.doAs} loses that attribution here: every export writes as
+   * whichever user opened the supplied instance, whoever requested it. This fails silently, so
+   * prefer {@link #createFileStore(String)} where per-user attribution matters.
+   *
+   * @param fileSystem the filesystem to write through
+   * @return a factory that creates stores over the supplied filesystem
+   */
+  @Nonnull
+  public static FileStoreFactory forFileSystem(@Nonnull final FileSystem fileSystem) {
+    return location -> new HdfsFileStore(fileSystem);
+  }
+
   @Nonnull
   @Override
   public FileStore createFileStore(@Nonnull final String location) throws IOException {

--- a/src/main/java/au/csiro/filestore/hdfs/HdfsFileStoreFactory.java
+++ b/src/main/java/au/csiro/filestore/hdfs/HdfsFileStoreFactory.java
@@ -32,17 +32,39 @@ import org.apache.hadoop.fs.Path;
 
 /**
  * File store factory based on Apache Hadoop HDFS FileSystem.
+ *
+ * <p>Filesystems are resolved through the JVM-wide Hadoop filesystem cache and are borrowed rather
+ * than owned, so closing a store never closes the filesystem behind it. Releasing cached instances
+ * is the host application's business; Hadoop closes what remains at JVM shutdown.
+ *
+ * <p>That obligation becomes a real one in a server that impersonates its users. The cache is keyed
+ * on scheme, authority and user, so each distinct user reaching a destination creates an instance
+ * that lives until the JVM exits. A server using {@code UserGroupInformation.doAs} should call
+ * {@code FileSystem.closeAllForUGI} when it tears a user's session down, or instances will
+ * accumulate for as long as the process runs.
  */
 public class HdfsFileStoreFactory implements FileStoreFactory {
 
   @Nonnull
   private final Configuration configuration;
 
+  /**
+   * Creates a factory that resolves filesystems through the Hadoop filesystem cache.
+   *
+   * <p>The configuration is only consulted when the cache has to construct a filesystem. The cache
+   * is keyed on scheme, authority and user alone, so if the host application has already opened a
+   * filesystem for the destination, that instance is returned and this configuration is ignored.
+   *
+   * @param configuration the configuration to construct filesystems from, on a cache miss
+   */
   public HdfsFileStoreFactory(@Nonnull final Configuration configuration) {
-    // here we use scala.Option
     this.configuration = configuration;
   }
 
+  /**
+   * Creates a factory that resolves filesystems through the Hadoop filesystem cache, using a
+   * default configuration when the cache has to construct one.
+   */
   public HdfsFileStoreFactory() {
     this(new Configuration());
   }
@@ -59,6 +81,12 @@ public class HdfsFileStoreFactory implements FileStoreFactory {
     @Nonnull
     private final FileSystem fileSystem;
 
+    /**
+     * Creates a store over a filesystem supplied by the caller. The filesystem is borrowed: the
+     * caller retains ownership and remains responsible for closing it.
+     *
+     * @param fileSystem the filesystem to use
+     */
     HdfsFileStore(@Nonnull final FileSystem fileSystem) {
       this.fileSystem = fileSystem;
     }
@@ -70,8 +98,15 @@ public class HdfsFileStoreFactory implements FileStoreFactory {
     }
 
     @Override
-    public void close() throws IOException {
-      fileSystem.close();
+    public void close() {
+      // The filesystem is borrowed, never owned, so this store does not close it. It comes either
+      // from the caller or from the JVM-wide Hadoop cache, which is shared with the host
+      // application; closing a cached instance evicts it and leaves the application holding a
+      // closed filesystem. Cached instances are released by Hadoop's own shutdown hook.
+      //
+      // Files are already durable without this: each write is committed by the try-with-resources
+      // around fileSystem.create in writeAll, which finalises the file through the HDFS write
+      // pipeline and completes the upload on object stores.
     }
 
     @Value

--- a/src/test/java/au/csiro/filestore/hdfs/HdfsFileStoreFactoryTest.java
+++ b/src/test/java/au/csiro/filestore/hdfs/HdfsFileStoreFactoryTest.java
@@ -77,4 +77,17 @@ public class HdfsFileStoreFactoryTest extends AbstractFileStoreFactoryTest {
 
     verify(borrowed, never()).close();
   }
+
+  /**
+   * A store built over a caller-supplied filesystem writes through that instance and leaves it
+   * open, so that the caller can keep using it once the export has finished.
+   */
+  @Test
+  void testFactoryForSuppliedFileSystemLeavesItOpen() throws IOException {
+    final FileSystem supplied = mock(FileSystem.class);
+
+    HdfsFileStoreFactory.forFileSystem(supplied).createFileStore(testRootDir.toString()).close();
+
+    verify(supplied, never()).close();
+  }
 }

--- a/src/test/java/au/csiro/filestore/hdfs/HdfsFileStoreFactoryTest.java
+++ b/src/test/java/au/csiro/filestore/hdfs/HdfsFileStoreFactoryTest.java
@@ -17,10 +17,20 @@
 
 package au.csiro.filestore.hdfs;
 
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
 import au.csiro.filestore.AbstractFileStoreFactoryTest;
+import au.csiro.filestore.FileStore;
 import au.csiro.filestore.FileStoreFactory;
 import java.io.IOException;
+import java.net.URI;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests for {@link HdfsFileStoreFactory}.
@@ -32,5 +42,39 @@ public class HdfsFileStoreFactoryTest extends AbstractFileStoreFactoryTest {
   @BeforeEach
   void setUp() throws IOException {
     fileStore = fileStoreFactory.createFileStore(testRootDir.toString());
+  }
+
+  /**
+   * Closing a store must not disturb the filesystem instance that the host application shares
+   * through the Hadoop filesystem cache. Closing a cached instance evicts it from the cache, so the
+   * application's reference is left closed and a later lookup returns a different instance. For
+   * schemes that guard against use after close, such as S3A, that leaves the application unable to
+   * reach the scheme at all.
+   */
+  @Test
+  void testClosingStoreLeavesTheCachedFileSystemInPlace() throws IOException {
+    final URI location = URI.create(testRootDir.toString());
+    final FileSystem cached = FileSystem.get(location, new Configuration());
+
+    try (final FileStore store = fileStoreFactory.createFileStore(testRootDir.toString())) {
+      store.get(testRootDir.resolve("some-directory").toString()).mkdirs();
+    }
+
+    // The cached instance must still be the one the application gets, and must not have been
+    // evicted by the store closing it.
+    assertSame(cached, FileSystem.get(location, new Configuration()));
+  }
+
+  /**
+   * The filesystem is always borrowed, whether it came from the caller or from the Hadoop cache, so
+   * closing a store must never close it.
+   */
+  @Test
+  void testClosingStoreDoesNotCloseTheFileSystem() throws IOException {
+    final FileSystem borrowed = mock(FileSystem.class);
+
+    new HdfsFileStoreFactory.HdfsFileStore(borrowed).close();
+
+    verify(borrowed, never()).close();
   }
 }


### PR DESCRIPTION
Fixes #12.

`createFileStore` took its filesystem from `FileSystem.get`, which returns an instance from a JVM-wide cache shared with the host application, and `close()` then closed it. Since `BulkExportClient.export()` manages the store in a try-with-resources block, every successful export closed the caller's filesystem, leaving a closed instance in the cache and breaking all later access to that scheme.

In Pathling this showed up as a ping and pull import downloading every file correctly and then failing with `FileSystem is closed!`, with all subsequent jobs failing until the pod was restarted.

## The remedy

The bug is in the closing, not the getting, so `close()` is now a no-op — the filesystem is borrowed and the store owns nothing to release.

An earlier version of this branch instead switched to `FileSystem.newInstance`, so that the store owned what it closed. That fixes the eviction but changes which filesystem the export writes through, and not for the better. `FileSystem.get` keys its cache on scheme, authority and user only — the `Configuration` is not part of the key and is consulted just once, when an instance actually has to be constructed. `newInstance` has no such shortcut, so the bare `new Configuration()` from the no-arg constructor would have become the sole basis for the filesystem. Under Spark that is the difference between inheriting `spark.hadoop.fs.s3a.*` credentials and building an S3A client from classpath XML alone, and it stands up a fresh client, connection pool and credential resolution on every export.

Resolving through the cache is therefore worth keeping rather than working around. What it returns is the host application's own instance — already configured, already authenticated, better than anything this library would construct. The `Configuration` being ignored on a cache hit is benign for exactly that reason.

Files are already durable without `close()`. Each write is committed by the try-with-resources around `fileSystem.create` in `writeAll`, which finalises the file through the HDFS write pipeline and completes the upload on object stores. `FileSystem.close()` is client and pool teardown and never contributed to durability.

## Documented, having previously been silent

- The `Configuration` is ignored on a cache hit, so it only takes effect on first touch of a scheme. Callers should pass the configuration their application already holds, so that the cold path is right too.
- The cache key includes the user, so a server impersonating its users through `UserGroupInformation.doAs` accumulates one instance per user for the life of the process, and needs to call `FileSystem.closeAllForUGI` on session teardown.
- `forFileSystem` fixes the identity that writes are performed as, because a Hadoop filesystem captures its user at construction. Under impersonation that silently defeats per-user attribution, so `createFileStore` remains the right choice where attribution matters.

## Testing

`testClosingStoreLeavesTheCachedFileSystemInPlace` is a behavioural test rather than a mock verification: reinstating the old `close()` makes it fail with a real assertion failure on filesystem identity. It passes under both candidate remedies, so it pins the contract rather than the mechanism.

111 tests pass.

## Notes

No version bump. `RELEASE_CHECKLIST.md` makes the SNAPSHOT bump a post-release step on `main`, and the repository has always done it that way. Worth deciding separately that this adds public API (`forFileSystem`), which under `CONTRIBUTING.md`'s SemVer policy is a minor rather than a patch.

The download-retry work that was previously on this branch has moved to #16, which fixes #15. The two are independent and touch disjoint files.