### PR TITLE
Retry a download whose transfer is cut short

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,6 +270,8 @@ or by providing a customised sub-configuration objects.
   transient errors, max pooling delay)
 - `HttpClientConfig` - customise the HTTP client configuration (e.g. retry
   count, socket timeout)
+- `DownloadConfig` - customise how a download whose transfer is cut short
+  mid-body is retried (e.g. max retries)
 
 ```java
 // The FHIR endpoint URL for https://bulk-data.smarthealthit.org/.
@@ -290,6 +292,11 @@ final HttpClientConfig httpClientConfig = HttpClientConfig.builder()
         .socketTimeout(10_000)
         .build();
 
+// Create a customised download configuration.
+final DownloadConfig downloadConfig = DownloadConfig.builder()
+        .maxRetries(9) // Retries per file, on top of the first attempt.
+        .build();
+
 // Build the client with a system level and customised run-time configuration.
 final BulkExportResult result = BulkExportClient.systemBuilder()
         .withFhirEndpointUrl(fhirEndpointUrl)
@@ -298,6 +305,7 @@ final BulkExportResult result = BulkExportClient.systemBuilder()
         .withTimeout(Duration.ofMinutes(60))
         .withAsyncConfig(asyncConfig)
         .withHttpClientConfig(httpClientConfig)
+        .withDownloadConfig(downloadConfig)
         .build()
         .export();
 ```

--- a/README.md
+++ b/README.md
@@ -270,8 +270,8 @@ or by providing a customised sub-configuration objects.
   transient errors, max pooling delay)
 - `HttpClientConfig` - customise the HTTP client configuration (e.g. retry
   count, socket timeout)
-- `DownloadConfig` - customise how a download whose transfer is cut short
-  mid-body is retried (e.g. max retries, max retry delay)
+- `DownloadConfig` - customise how a failed download of an output file is
+  retried (e.g. max retries, max retry delay)
 
 ```java
 // The FHIR endpoint URL for https://bulk-data.smarthealthit.org/.

--- a/README.md
+++ b/README.md
@@ -271,7 +271,7 @@ or by providing a customised sub-configuration objects.
 - `HttpClientConfig` - customise the HTTP client configuration (e.g. retry
   count, socket timeout)
 - `DownloadConfig` - customise how a download whose transfer is cut short
-  mid-body is retried (e.g. max retries)
+  mid-body is retried (e.g. max retries, max retry delay)
 
 ```java
 // The FHIR endpoint URL for https://bulk-data.smarthealthit.org/.
@@ -295,6 +295,7 @@ final HttpClientConfig httpClientConfig = HttpClientConfig.builder()
 // Create a customised download configuration.
 final DownloadConfig downloadConfig = DownloadConfig.builder()
         .maxRetries(9) // Retries per file, on top of the first attempt.
+        .maxRetryDelay(Duration.ofSeconds(5)) // Each delay is random, up to this.
         .build();
 
 // Build the client with a system level and customised run-time configuration.

--- a/src/main/java/au/csiro/fhir/export/BulkExportClient.java
+++ b/src/main/java/au/csiro/fhir/export/BulkExportClient.java
@@ -24,6 +24,7 @@ import au.csiro.fhir.auth.AuthConfig;
 import au.csiro.fhir.auth.SMARTTokenCredentialFactory;
 import au.csiro.fhir.auth.TokenCredentialFactory;
 import au.csiro.fhir.export.BulkExportResult.FileResult;
+import au.csiro.fhir.export.download.DownloadConfig;
 import au.csiro.fhir.export.download.UrlDownloadTemplate;
 import au.csiro.fhir.export.download.UrlDownloadTemplate.UrlDownloadEntry;
 import au.csiro.fhir.export.ws.AssociatedData;
@@ -219,6 +220,14 @@ public class BulkExportClient {
   @Builder.Default
   AsyncConfig asyncConfig = AsyncConfig.builder().build();
 
+  /**
+   * The configuration for the download of the output files.
+   */
+  @Nonnull
+  @Valid
+  @Builder.Default
+  DownloadConfig downloadConfig = DownloadConfig.builder().build();
+
 
   /**
    * The configuration for the authentication.
@@ -307,7 +316,7 @@ public class BulkExportClient {
           new BulkExportAsyncService(httpClient, URI.create(fhirEndpointUrl)),
           asyncConfig);
       final UrlDownloadTemplate downloadTemplate = new UrlDownloadTemplate(httpClient,
-          executorServiceResource.getExecutorService());
+          executorServiceResource.getExecutorService(), downloadConfig);
 
       final BulkExportResult result = doExport(fileStore, bulkExportTemplate, downloadTemplate);
       log.info("Export successful: {}", result);

--- a/src/main/java/au/csiro/fhir/export/download/DownloadConfig.java
+++ b/src/main/java/au/csiro/fhir/export/download/DownloadConfig.java
@@ -47,8 +47,8 @@ public class DownloadConfig {
    */
   @Nonnull
   @Builder.Default
-  // The default message for this constraint is an EL template, which is left uninterpolated
-  // without an EL implementation on the classpath, so it is spelled out here instead.
+  // The default message for this constraint is an EL template, and ValidationUtils interpolates
+  // with a ParameterMessageInterpolator, which does not evaluate EL, so it is spelled out here.
   @DurationMin(nanos = 0, message = "must not be negative")
   Duration maxRetryDelay = Duration.ofSeconds(2);
 }

--- a/src/main/java/au/csiro/fhir/export/download/DownloadConfig.java
+++ b/src/main/java/au/csiro/fhir/export/download/DownloadConfig.java
@@ -17,9 +17,12 @@
 
 package au.csiro.fhir.export.download;
 
+import java.time.Duration;
+import javax.annotation.Nonnull;
 import jakarta.validation.constraints.Min;
 import lombok.Builder;
 import lombok.Value;
+import org.hibernate.validator.constraints.time.DurationMin;
 
 /**
  * Configuration relating to the download of the output files of an export.
@@ -35,4 +38,16 @@ public class DownloadConfig {
   @Builder.Default
   @Min(0)
   int maxRetries = 4;
+
+  /**
+   * The longest that a retry of a file is delayed. Each delay is a random value up to this, so
+   * that downloads cut short together do not all retry at the same moment. Zero retries
+   * immediately.
+   */
+  @Nonnull
+  @Builder.Default
+  // The default message for this constraint is an EL template, which is left uninterpolated
+  // without an EL implementation on the classpath, so it is spelled out here instead.
+  @DurationMin(nanos = 0, message = "must not be negative")
+  Duration maxRetryDelay = Duration.ofSeconds(2);
 }

--- a/src/main/java/au/csiro/fhir/export/download/DownloadConfig.java
+++ b/src/main/java/au/csiro/fhir/export/download/DownloadConfig.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2023 Commonwealth Scientific and Industrial Research
+ * Organisation (CSIRO) ABN 41 687 119 230.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package au.csiro.fhir.export.download;
+
+import jakarta.validation.constraints.Min;
+import lombok.Builder;
+import lombok.Value;
+
+/**
+ * Configuration relating to the download of the output files of an export.
+ */
+@Value
+@Builder
+public class DownloadConfig {
+
+  /**
+   * The number of times a single file is retried after its first attempt fails. Zero disables
+   * retrying, so the default of four allows five attempts in total.
+   */
+  @Builder.Default
+  @Min(0)
+  int maxRetries = 4;
+}

--- a/src/main/java/au/csiro/fhir/export/download/DownloadConfig.java
+++ b/src/main/java/au/csiro/fhir/export/download/DownloadConfig.java
@@ -32,8 +32,9 @@ import org.hibernate.validator.constraints.time.DurationMin;
 public class DownloadConfig {
 
   /**
-   * The number of times a single file is retried after its first attempt fails. Zero disables
-   * retrying, so the default of four allows five attempts in total.
+   * The number of times a single file is retried after its first attempt fails, for a failure that
+   * is not known to be permanent. Zero disables retrying, so the default of four allows five
+   * attempts in total.
    */
   @Builder.Default
   @Min(0)

--- a/src/main/java/au/csiro/fhir/export/download/UrlDownloadTemplate.java
+++ b/src/main/java/au/csiro/fhir/export/download/UrlDownloadTemplate.java
@@ -163,8 +163,9 @@ public class UrlDownloadTemplate {
     public Long call() throws Exception {
       // A body that ends early is only discovered while it is being read, which is after the HTTP
       // client has stopped considering the request retryable. Retry here so that one interrupted
-      // transfer does not discard an export that may run to thousands of files. The file is
-      // rewritten from the start, so a partial write from the previous attempt is replaced.
+      // transfer does not discard an export that may run to thousands of files. A partial write
+      // from the previous attempt is replaced, since writeAll requires the file to be written from
+      // the start.
       //
       // Every failure of an attempt is retried unless it is known to be permanent. A rejected
       // request is excluded by construction, since HttpError is not an IOException.

--- a/src/main/java/au/csiro/fhir/export/download/UrlDownloadTemplate.java
+++ b/src/main/java/au/csiro/fhir/export/download/UrlDownloadTemplate.java
@@ -39,6 +39,7 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
@@ -121,6 +122,22 @@ public class UrlDownloadTemplate {
         || e instanceof SocketException;
   }
 
+  /**
+   * How long to wait before the next attempt at a file. Downloads run concurrently against a
+   * single endpoint, so a fault that cuts several of them short at once would otherwise have them
+   * all retry in step. Spreading each one at random across the configured window breaks that up,
+   * and holds the wait to a bound, since a waiting task occupies one of the download threads.
+   *
+   * @return a delay of at most the configured maximum
+   */
+  @Nonnull
+  private Duration nextRetryDelay() {
+    final long maxMillis = config.getMaxRetryDelay().toMillis();
+    return maxMillis > 0
+           ? Duration.ofMillis(ThreadLocalRandom.current().nextLong(maxMillis + 1))
+           : Duration.ZERO;
+  }
+
   @Value
   class UriDownloadTask implements Callable<Long> {
 
@@ -153,8 +170,10 @@ public class UrlDownloadTemplate {
             log.error("Failed to download {} after {} attempts", source, attempt);
             throw e;
           }
-          log.warn("Download of {} failed on attempt {} of {} ({}), retrying", source,
-              attempt, maxAttempts, e.getMessage());
+          final Duration delay = nextRetryDelay();
+          log.warn("Download of {} failed on attempt {} of {} ({}), retrying in {}", source,
+              attempt, maxAttempts, e.getMessage(), delay);
+          TimeUnit.MILLISECONDS.sleep(delay.toMillis());
         }
       }
     }

--- a/src/main/java/au/csiro/fhir/export/download/UrlDownloadTemplate.java
+++ b/src/main/java/au/csiro/fhir/export/download/UrlDownloadTemplate.java
@@ -26,7 +26,9 @@ import au.csiro.fhir.export.BulkExportException.DownloadError;
 import au.csiro.fhir.export.BulkExportException.HttpError;
 import au.csiro.fhir.export.BulkExportException.Timeout;
 import au.csiro.filestore.FileStore.FileHandle;
+import java.io.IOException;
 import java.io.InputStream;
+import java.net.SocketException;
 import java.net.URI;
 import java.time.Duration;
 import java.time.Instant;
@@ -42,7 +44,9 @@ import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
 import lombok.Value;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.http.ConnectionClosedException;
 import org.apache.http.HttpResponse;
+import org.apache.http.MalformedChunkCodingException;
 import org.apache.http.client.HttpClient;
 import org.apache.http.client.methods.HttpGet;
 
@@ -50,8 +54,9 @@ import org.apache.http.client.methods.HttpGet;
  * A template class for concurrent download of multiple URLs into a file store. The file store can
  * be any concrete implementation of the {@link FileStore} abstraction.
  * <p>
- * This implementation fails fast: all the downloads are terminated on the first failure in any of
- * the downloads.
+ * A download whose transfer is cut short mid-body is retried, since that is a transient fault.
+ * Once a single download has used up its attempts this implementation fails fast: all the
+ * remaining downloads are terminated.
  * <p>
  * No cleanup is performed on failure - partial results may be left for some of the URLs.
  */
@@ -92,6 +97,30 @@ public class UrlDownloadTemplate {
   @Nonnull
   ExecutorService executorService;
 
+  /**
+   * The configuration governing how a failed download is retried.
+   */
+  @Nonnull
+  DownloadConfig config;
+
+  /**
+   * Recognises a transfer that was cut short before the message was complete. Apache's body
+   * decoders raise these when the connection closes or is reset part way through, and no other
+   * part of a download does, so a broken transfer is told apart from a destination that cannot be
+   * written to by the type of the failure rather than by where it was thrown.
+   *
+   * @param e the failure that ended the attempt
+   * @return true if the transfer was cut short, and so is worth repeating
+   */
+  private static boolean isTruncatedBody(@Nonnull final IOException e) {
+    // ConnectionClosedException is a Content-Length delimited body ending early, and
+    // MalformedChunkCodingException, with its TruncatedChunkException subclass, the chunked
+    // equivalent. A SocketException is the same fault arriving as a reset rather than a close.
+    return e instanceof ConnectionClosedException
+        || e instanceof MalformedChunkCodingException
+        || e instanceof SocketException;
+  }
+
   @Value
   class UriDownloadTask implements Callable<Long> {
 
@@ -103,9 +132,46 @@ public class UrlDownloadTemplate {
 
     @Override
     public Long call() throws Exception {
+      // A body that ends early is only discovered while it is being read, which is after the HTTP
+      // client has stopped considering the request retryable. Retry here so that one interrupted
+      // transfer does not discard an export that may run to thousands of files. The file is
+      // rewritten from the start, so a partial write from the previous attempt is replaced.
+      //
+      // Only a transfer cut short is retried. A destination that cannot be written to will not be
+      // fixed by fetching the body again, and re-downloading a large file to meet the same full
+      // disk or rejected write wastes the transfer. Failures of the request itself are left to the
+      // HTTP client, which retries them already.
+      final int maxAttempts = config.getMaxRetries() + 1;
+      for (int attempt = 1; ; attempt++) {
+        try {
+          return attemptDownload();
+        } catch (final IOException e) {
+          if (!isTruncatedBody(e)) {
+            throw e;
+          }
+          if (attempt >= maxAttempts) {
+            log.error("Failed to download {} after {} attempts", source, attempt);
+            throw e;
+          }
+          log.warn("Download of {} failed on attempt {} of {} ({}), retrying", source,
+              attempt, maxAttempts, e.getMessage());
+        }
+      }
+    }
+
+    /**
+     * Performs a single download attempt.
+     *
+     * @return the number of bytes written
+     * @throws IOException if the body ends before it has been read in full, the request fails, or
+     * the destination cannot be written to
+     */
+    private long attemptDownload() throws IOException {
       log.debug("Starting download from:  {}  to: {}", source, destination);
       final HttpResponse result = httpClient.execute(new HttpGet(source));
       if (result.getStatusLine().getStatusCode() != 200) {
+        // The server has rejected the request rather than failed to deliver it, so repeating it
+        // would only add load. HttpError is not an IOException and so is not retried.
         log.error("Failed to download: {}. Status: {}", source, result.getStatusLine());
         throw new HttpError(
             "Failed to download: " + source, result.getStatusLine().getStatusCode());
@@ -125,11 +191,13 @@ public class UrlDownloadTemplate {
    * externally).
    * @param executorService the executor service to use for concurrent downloads (its life cycle
    * should be managed externally).
+   * @param config the configuration governing how a failed download is retried.
    */
   public UrlDownloadTemplate(@Nonnull final HttpClient httpClient,
-      @Nonnull final ExecutorService executorService) {
+      @Nonnull final ExecutorService executorService, @Nonnull final DownloadConfig config) {
     this.httpClient = httpClient;
     this.executorService = executorService;
+    this.config = config;
   }
 
   /**

--- a/src/main/java/au/csiro/fhir/export/download/UrlDownloadTemplate.java
+++ b/src/main/java/au/csiro/fhir/export/download/UrlDownloadTemplate.java
@@ -237,6 +237,20 @@ public class UrlDownloadTemplate {
   }
 
   /**
+   * Creates a new instance of the template with the default download configuration, which retries a
+   * failed download four times.
+   *
+   * @param httpClient the HTTP client to use for downloading (its life cycle should be managed
+   * externally).
+   * @param executorService the executor service to use for concurrent downloads (its life cycle
+   * should be managed externally).
+   */
+  public UrlDownloadTemplate(@Nonnull final HttpClient httpClient,
+      @Nonnull final ExecutorService executorService) {
+    this(httpClient, executorService, DownloadConfig.builder().build());
+  }
+
+  /**
    * Downloads the given URLs concurrently to provided destinations in a
    * {@link FileStore}.
    *

--- a/src/main/java/au/csiro/fhir/export/download/UrlDownloadTemplate.java
+++ b/src/main/java/au/csiro/fhir/export/download/UrlDownloadTemplate.java
@@ -26,10 +26,14 @@ import au.csiro.fhir.export.BulkExportException.DownloadError;
 import au.csiro.fhir.export.BulkExportException.HttpError;
 import au.csiro.fhir.export.BulkExportException.Timeout;
 import au.csiro.filestore.FileStore.FileHandle;
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
-import java.net.SocketException;
+import java.io.InterruptedIOException;
 import java.net.URI;
+import java.nio.channels.ClosedByInterruptException;
+import java.nio.file.AccessDeniedException;
+import java.nio.file.NoSuchFileException;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.Collection;
@@ -45,9 +49,7 @@ import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
 import lombok.Value;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.http.ConnectionClosedException;
 import org.apache.http.HttpResponse;
-import org.apache.http.MalformedChunkCodingException;
 import org.apache.http.client.HttpClient;
 import org.apache.http.client.methods.HttpGet;
 
@@ -55,9 +57,9 @@ import org.apache.http.client.methods.HttpGet;
  * A template class for concurrent download of multiple URLs into a file store. The file store can
  * be any concrete implementation of the {@link FileStore} abstraction.
  * <p>
- * A download whose transfer is cut short mid-body is retried, since that is a transient fault.
- * Once a single download has used up its attempts this implementation fails fast: all the
- * remaining downloads are terminated.
+ * A download that fails is retried, unless the failure is one that is known to be permanent. Once a
+ * single download has used up its attempts this implementation fails fast: all the remaining
+ * downloads are terminated.
  * <p>
  * No cleanup is performed on failure - partial results may be left for some of the URLs.
  */
@@ -105,21 +107,31 @@ public class UrlDownloadTemplate {
   DownloadConfig config;
 
   /**
-   * Recognises a transfer that was cut short before the message was complete. Apache's body
-   * decoders raise these when the connection closes or is reset part way through, and no other
-   * part of a download does, so a broken transfer is told apart from a destination that cannot be
-   * written to by the type of the failure rather than by where it was thrown.
+   * Decides whether a failed attempt is worth repeating. Anything that is not known to be permanent
+   * is, because the two ways of being wrong here cost wildly different amounts: repeating a
+   * permanent failure wastes one file's transfers and then fails anyway, whereas declining to
+   * repeat a transient one abandons an export that may represent hours of server-side processing.
+   * Listing what must not be repeated therefore fails in the cheaper direction than listing what
+   * may be, and does not depend on which exception type a given transport or {@link FileStore}
+   * implementation happens to raise for a transfer that was cut short.
    *
    * @param e the failure that ended the attempt
-   * @return true if the transfer was cut short, and so is worth repeating
+   * @return true unless the failure is known to be permanent
    */
-  private static boolean isTruncatedBody(@Nonnull final IOException e) {
-    // ConnectionClosedException is a Content-Length delimited body ending early, and
-    // MalformedChunkCodingException, with its TruncatedChunkException subclass, the chunked
-    // equivalent. A SocketException is the same fault arriving as a reset rather than a close.
-    return e instanceof ConnectionClosedException
-        || e instanceof MalformedChunkCodingException
-        || e instanceof SocketException;
+  private static boolean isWorthRetrying(@Nonnull final IOException e) {
+    // Cancellation must be honoured rather than retried: download() interrupts the outstanding
+    // tasks once any one of them has failed, and a task that swallowed that would keep issuing
+    // requests for an export that has already been abandoned.
+    if (e instanceof InterruptedIOException || e instanceof ClosedByInterruptException) {
+      return false;
+    }
+    // A destination that does not exist or cannot be opened is a misconfigured output location
+    // rather than a fault in transit, so no number of attempts will make it writable. Note that a
+    // destination which fails part way through a write is not in this class: on a file store that
+    // writes over the network that is usually transient, so it is retried.
+    return !(e instanceof AccessDeniedException
+        || e instanceof NoSuchFileException
+        || e instanceof FileNotFoundException);
   }
 
   /**
@@ -154,25 +166,29 @@ public class UrlDownloadTemplate {
       // transfer does not discard an export that may run to thousands of files. The file is
       // rewritten from the start, so a partial write from the previous attempt is replaced.
       //
-      // Only a transfer cut short is retried. A destination that cannot be written to will not be
-      // fixed by fetching the body again, and re-downloading a large file to meet the same full
-      // disk or rejected write wastes the transfer. Failures of the request itself are left to the
-      // HTTP client, which retries them already.
+      // Every failure of an attempt is retried unless it is known to be permanent. A rejected
+      // request is excluded by construction, since HttpError is not an IOException.
       final int maxAttempts = config.getMaxRetries() + 1;
       for (int attempt = 1; ; attempt++) {
         try {
           return attemptDownload();
-        } catch (final IOException e) {
-          if (!isTruncatedBody(e)) {
-            throw e;
+        } catch (final IOException ex) {
+          if (!isWorthRetrying(ex)) {
+            throw ex;
           }
           if (attempt >= maxAttempts) {
             log.error("Failed to download {} after {} attempts", source, attempt);
-            throw e;
+            throw ex;
+          }
+          // The delay cannot be relied on to observe a cancellation, because a zero delay - either
+          // configured or drawn by the jitter - neither sleeps nor throws. Check for it directly so
+          // that a cancelled download stops here rather than starting another attempt.
+          if (Thread.interrupted()) {
+            throw new InterruptedException("Download of " + source + " was cancelled");
           }
           final Duration delay = nextRetryDelay();
-          log.warn("Download of {} failed on attempt {} of {} ({}), retrying in {}", source,
-              attempt, maxAttempts, e.getMessage(), delay);
+          log.debug("Download of {} failed on attempt {} of {} ({}), retrying in {}", source,
+              attempt, maxAttempts, ex.getMessage(), delay);
           TimeUnit.MILLISECONDS.sleep(delay.toMillis());
         }
       }

--- a/src/main/java/au/csiro/filestore/FileStore.java
+++ b/src/main/java/au/csiro/filestore/FileStore.java
@@ -76,7 +76,13 @@ public interface FileStore extends Closeable {
     URI toUri();
 
     /**
-     * Write the contents of the input stream to the file.
+     * Write the contents of the input stream to the file, replacing anything already there.
+     * <p>
+     * The file must be written from the start rather than appended to, and must be left holding
+     * exactly the bytes read from the stream. A download that is retried calls this again on the
+     * same handle after an earlier attempt failed part way through, so an implementation that
+     * appended, or that left the tail of a longer earlier write in place, would silently corrupt
+     * the output.
      *
      * @param inputStream the input stream to write.
      * @return the number of bytes written.

--- a/src/main/java/au/csiro/http/HttpClientConfig.java
+++ b/src/main/java/au/csiro/http/HttpClientConfig.java
@@ -79,7 +79,9 @@ public class HttpClientConfig implements Serializable {
   private boolean retryEnabled = true;
 
   /**
-   * The number of times to retry failed terminology requests.
+   * The number of times to retry a failed request. This is applied by the HTTP client while the
+   * request is in flight, so it does not cover a response body that ends early while being read -
+   * that is retried per file during download instead.
    */
   @NotNull
   @Min(1)

--- a/src/test/java/au/csiro/fhir/example/BulkDataCustomisedExportApp.java
+++ b/src/test/java/au/csiro/fhir/example/BulkDataCustomisedExportApp.java
@@ -2,6 +2,7 @@ package au.csiro.fhir.example;
 
 import au.csiro.fhir.export.BulkExportClient;
 import au.csiro.fhir.export.BulkExportResult;
+import au.csiro.fhir.export.download.DownloadConfig;
 import au.csiro.fhir.export.ws.AsyncConfig;
 import au.csiro.http.HttpClientConfig;
 
@@ -30,7 +31,11 @@ public class BulkDataCustomisedExportApp {
         .retryCount(5)
         .socketTimeout(10_000)
         .build();
-    
+
+    final DownloadConfig downloadConfig = DownloadConfig.builder()
+        .maxRetries(9)
+        .build();
+
     final BulkExportResult result = BulkExportClient.systemBuilder()
         .withFhirEndpointUrl(fhirEndpointUrl)
         .withOutputDir(outputDir)
@@ -38,6 +43,7 @@ public class BulkDataCustomisedExportApp {
         .withTimeout(Duration.ofMinutes(60))
         .withAsyncConfig(asyncConfig)
         .withHttpClientConfig(httpClientConfig)
+        .withDownloadConfig(downloadConfig)
         .build()
         .export();
     

--- a/src/test/java/au/csiro/fhir/example/BulkDataCustomisedExportApp.java
+++ b/src/test/java/au/csiro/fhir/example/BulkDataCustomisedExportApp.java
@@ -34,6 +34,7 @@ public class BulkDataCustomisedExportApp {
 
     final DownloadConfig downloadConfig = DownloadConfig.builder()
         .maxRetries(9)
+        .maxRetryDelay(Duration.ofSeconds(5))
         .build();
 
     final BulkExportResult result = BulkExportClient.systemBuilder()

--- a/src/test/java/au/csiro/fhir/export/BulkExportClientBuilderTest.java
+++ b/src/test/java/au/csiro/fhir/export/BulkExportClientBuilderTest.java
@@ -24,6 +24,7 @@ import au.csiro.fhir.auth.AuthConfig;
 import au.csiro.fhir.export.BulkExportClient.BulkExportClientBuilder;
 import au.csiro.fhir.export.download.DownloadConfig;
 import jakarta.validation.ConstraintViolationException;
+import java.time.Duration;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -51,8 +52,8 @@ public class BulkExportClientBuilderTest {
   }
 
   /**
-   * A retry count is counted down, so it cannot be negative. It is rejected when the client is
-   * built rather than part way through an export.
+   * A delay is slept for and a retry count is counted down, so neither can be negative. They are
+   * rejected when the client is built rather than part way through an export.
    */
   @Test
   void testFailsEarlyWithInvalidDownloadConfiguration() {
@@ -62,6 +63,7 @@ public class BulkExportClientBuilderTest {
         .withOutputDir("output-dir")
         .withDownloadConfig(DownloadConfig.builder()
             .maxRetries(-1)
+            .maxRetryDelay(Duration.ofSeconds(-1))
             .build());
 
     final ConstraintViolationException ex = assertThrows(ConstraintViolationException.class,
@@ -69,7 +71,8 @@ public class BulkExportClientBuilderTest {
 
     assertEquals(
         "Invalid Bulk Export Client Configuration\n"
-            + "downloadConfig.maxRetries: must be greater than or equal to 0",
+            + "downloadConfig.maxRetries: must be greater than or equal to 0\n"
+            + "downloadConfig.maxRetryDelay: must not be negative",
         ex.getMessage());
   }
 

--- a/src/test/java/au/csiro/fhir/export/BulkExportClientBuilderTest.java
+++ b/src/test/java/au/csiro/fhir/export/BulkExportClientBuilderTest.java
@@ -22,6 +22,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import au.csiro.fhir.auth.AuthConfig;
 import au.csiro.fhir.export.BulkExportClient.BulkExportClientBuilder;
+import au.csiro.fhir.export.download.DownloadConfig;
 import jakarta.validation.ConstraintViolationException;
 import org.junit.jupiter.api.Test;
 
@@ -46,6 +47,29 @@ public class BulkExportClientBuilderTest {
             + "authConfig.clientId: must be supplied if auth is enabled\n"
             + "authConfig: either clientSecret or privateKeyJWK must be supplied if auth is enabled\n"
             + "fhirEndpointUrl: must be a valid URL",
+        ex.getMessage());
+  }
+
+  /**
+   * A retry count is counted down, so it cannot be negative. It is rejected when the client is
+   * built rather than part way through an export.
+   */
+  @Test
+  void testFailsEarlyWithInvalidDownloadConfiguration() {
+
+    final BulkExportClientBuilder invalidBuilder = BulkExportClient.builder()
+        .withFhirEndpointUrl("http://foo.bar/fhir")
+        .withOutputDir("output-dir")
+        .withDownloadConfig(DownloadConfig.builder()
+            .maxRetries(-1)
+            .build());
+
+    final ConstraintViolationException ex = assertThrows(ConstraintViolationException.class,
+        invalidBuilder::build);
+
+    assertEquals(
+        "Invalid Bulk Export Client Configuration\n"
+            + "downloadConfig.maxRetries: must be greater than or equal to 0",
         ex.getMessage());
   }
 

--- a/src/test/java/au/csiro/fhir/export/download/UrlDownloadTemplateTest.java
+++ b/src/test/java/au/csiro/fhir/export/download/UrlDownloadTemplateTest.java
@@ -180,6 +180,15 @@ class UrlDownloadTemplateTest {
   }
 
   /**
+   * The two-argument constructor predates the configuration and is public API of a released
+   * version, so it keeps working and supplies the defaults rather than being taken away.
+   */
+  @Test
+  void testDefaultsTheConfigurationWhenNotGiven() {
+    assertEquals(DEFAULTS, new UrlDownloadTemplate(httpClient, executorService).config);
+  }
+
+  /**
    * A body that yields some bytes and then fails, as one cut short mid-transfer does.
    *
    * @param bytesBeforeFailure the number of bytes served before the failure

--- a/src/test/java/au/csiro/fhir/export/download/UrlDownloadTemplateTest.java
+++ b/src/test/java/au/csiro/fhir/export/download/UrlDownloadTemplateTest.java
@@ -18,6 +18,7 @@
 package au.csiro.fhir.export.download;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.eq;
@@ -36,12 +37,14 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.SocketException;
 import java.net.URI;
+import java.nio.file.AccessDeniedException;
 import java.time.Duration;
 import java.util.List;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import javax.annotation.Nonnull;
+import javax.net.ssl.SSLException;
 import org.apache.commons.io.IOUtils;
 import org.apache.http.ConnectionClosedException;
 import org.apache.http.HttpResponse;
@@ -235,6 +238,25 @@ class UrlDownloadTemplateTest {
   }
 
   /**
+   * A body cut short at the same moment the download is cancelled, which is the ordering that
+   * matters: the task is interrupted while it is in the middle of a transfer that then fails.
+   *
+   * @return the body
+   */
+  @Nonnull
+  private static InputStream truncatedBodyOnCancelledDownload() {
+    return new InputStream() {
+
+      @Override
+      public int read() throws IOException {
+        Thread.currentThread().interrupt();
+        throw new ConnectionClosedException(
+            "Premature end of Content-Length delimited message body");
+      }
+    };
+  }
+
+  /**
    * Copies the body through to a sink, so that a read failure surfaces from where it would in
    * production: part way through the copy that {@code writeAll} performs.
    */
@@ -398,49 +420,127 @@ class UrlDownloadTemplateTest {
   }
 
   /**
-   * Retrying is confined to a transfer that was cut short, which is recognised by the type of the
-   * failure. Any other way of reading the body failing is not known to be transient, so repeating
-   * the transfer for it is not assumed to help.
+   * A transfer cut short does not arrive as one recognisable type. Over TLS it surfaces as an
+   * {@link SSLException}, which the HTTP client also declines to retry, so nothing would retry the
+   * originating failure of this issue on the HTTPS endpoints every real server uses.
    */
   @Test
-  void testDownloadTaskDoesNotRetryOtherReadFailures() throws Exception {
+  void testDownloadTaskRetriesAfterTlsTruncation() throws Exception {
     when(httpClient.execute(Mockito.any())).thenReturn(httpResponse);
     when(httpResponse.getStatusLine()).thenReturn(
         new BasicStatusLine(new ProtocolVersion("http", 1, 1), 200, "OK"));
-    when(httpResponse.getEntity()).thenReturn(new InputStreamEntity(
-        bodyFailingAfter(1, new IOException("Malformed response")), 3));
+    when(httpResponse.getEntity())
+        .thenReturn(new InputStreamEntity(
+            bodyFailingAfter(1, new SSLException("Unexpected end of stream")), 3))
+        .thenReturn(new InputStreamEntity(new ByteArrayInputStream(new byte[]{1, 2, 3}), 3));
     writeAllConsumesTheBody();
 
     final UrlDownloadTemplate template = new UrlDownloadTemplate(httpClient, executorService,
         NO_DELAY);
-    final IOException ex = assertThrows(IOException.class,
-        () -> template.new UriDownloadTask(URI.create("http://foo.bar/file1"), fileHandle).call());
+    final long written = template.new UriDownloadTask(URI.create("http://foo.bar/file1"),
+        fileHandle).call();
 
-    assertEquals("Malformed response", ex.getMessage());
-    verify(httpClient, Mockito.times(1)).execute(Mockito.any());
+    assertEquals(3L, written);
+    verify(httpClient, Mockito.times(2)).execute(Mockito.any());
   }
 
   /**
-   * A destination that cannot be written to is not a broken transfer. Fetching the body again
-   * cannot fix a full disk or a rejected write, so the transfer is not repeated for it.
+   * Which type a cut-short transfer arrives as depends on the transport and on how the body was
+   * encoded, so a read failure is repeated whether or not it is one of the recognised shapes. The
+   * cost of being wrong is one file's transfers; the cost of not retrying a transient fault is the
+   * whole export.
    */
   @Test
-  void testDownloadTaskDoesNotRetryDestinationFailure() throws Exception {
+  void testDownloadTaskRetriesUnrecognisedReadFailures() throws Exception {
+    when(httpClient.execute(Mockito.any())).thenReturn(httpResponse);
+    when(httpResponse.getStatusLine()).thenReturn(
+        new BasicStatusLine(new ProtocolVersion("http", 1, 1), 200, "OK"));
+    when(httpResponse.getEntity())
+        .thenReturn(new InputStreamEntity(
+            bodyFailingAfter(1, new IOException("Malformed response")), 3))
+        .thenReturn(new InputStreamEntity(new ByteArrayInputStream(new byte[]{1, 2, 3}), 3));
+    writeAllConsumesTheBody();
+
+    final UrlDownloadTemplate template = new UrlDownloadTemplate(httpClient, executorService,
+        NO_DELAY);
+    final long written = template.new UriDownloadTask(URI.create("http://foo.bar/file1"),
+        fileHandle).call();
+
+    assertEquals(3L, written);
+    verify(httpClient, Mockito.times(2)).execute(Mockito.any());
+  }
+
+  /**
+   * A destination that fails part way through a write is not assumed to be permanent. On a file
+   * store that writes over the network, which {@code HdfsFileHandle} does, that is the common
+   * transient fault, and it cannot be told apart from a read failure by type in any case.
+   */
+  @Test
+  void testDownloadTaskRetriesDestinationFailureMidWrite() throws Exception {
+    when(httpClient.execute(Mockito.any())).thenReturn(httpResponse);
+    when(httpResponse.getStatusLine()).thenReturn(
+        new BasicStatusLine(new ProtocolVersion("http", 1, 1), 200, "OK"));
+    when(httpResponse.getEntity()).thenAnswer(
+        invocation -> new InputStreamEntity(new ByteArrayInputStream(new byte[]{1, 2, 3}), 3));
+    when(fileHandle.writeAll(Mockito.any()))
+        .thenThrow(new IOException("Connection reset by peer"))
+        .thenReturn(3L);
+
+    final UrlDownloadTemplate template = new UrlDownloadTemplate(httpClient, executorService,
+        NO_DELAY);
+    final long written = template.new UriDownloadTask(URI.create("http://foo.bar/file1"),
+        fileHandle).call();
+
+    assertEquals(3L, written);
+    verify(httpClient, Mockito.times(2)).execute(Mockito.any());
+  }
+
+  /**
+   * A destination that cannot be opened at all is a misconfigured output location rather than a
+   * fault in transit, so no number of attempts will make it writable and the transfer is not
+   * repeated for it.
+   */
+  @Test
+  void testDownloadTaskDoesNotRetryUnwritableDestination() throws Exception {
     when(httpClient.execute(Mockito.any())).thenReturn(httpResponse);
     when(httpResponse.getStatusLine()).thenReturn(
         new BasicStatusLine(new ProtocolVersion("http", 1, 1), 200, "OK"));
     when(httpResponse.getEntity()).thenReturn(
         new InputStreamEntity(new ByteArrayInputStream(new byte[]{1, 2, 3}), 3));
     when(fileHandle.writeAll(Mockito.any()))
-        .thenThrow(new IOException("No space left on device"));
+        .thenThrow(new AccessDeniedException("output-dir/file1"));
 
     final UrlDownloadTemplate template = new UrlDownloadTemplate(httpClient, executorService,
         NO_DELAY);
-    final IOException ex = assertThrows(IOException.class,
+    assertThrows(AccessDeniedException.class,
         () -> template.new UriDownloadTask(URI.create("http://foo.bar/file1"), fileHandle).call());
 
-    assertEquals("No space left on device", ex.getMessage());
     verify(httpClient, Mockito.times(1)).execute(Mockito.any());
+  }
+
+  /**
+   * Retrying must not outlive the export it belongs to. Once any one download has failed
+   * {@code download()} interrupts the rest, and a task that treated its own cancellation as a
+   * transient fault would keep issuing requests for work that has already been abandoned. A zero
+   * delay neither sleeps nor throws, so the interrupt has to be observed independently of it.
+   */
+  @Test
+  void testDownloadTaskStopsWhenCancelled() throws Exception {
+    when(httpClient.execute(Mockito.any())).thenReturn(httpResponse);
+    when(httpResponse.getStatusLine()).thenReturn(
+        new BasicStatusLine(new ProtocolVersion("http", 1, 1), 200, "OK"));
+    when(httpResponse.getEntity()).thenAnswer(
+        invocation -> new InputStreamEntity(truncatedBodyOnCancelledDownload(), 3));
+    writeAllConsumesTheBody();
+
+    final UrlDownloadTemplate template = new UrlDownloadTemplate(httpClient, executorService,
+        NO_DELAY);
+    assertThrows(InterruptedException.class,
+        () -> template.new UriDownloadTask(URI.create("http://foo.bar/file1"), fileHandle).call());
+
+    verify(httpClient, Mockito.times(1)).execute(Mockito.any());
+    assertFalse(Thread.currentThread().isInterrupted(),
+        "The interrupt should have been consumed by the InterruptedException");
   }
 
   /**

--- a/src/test/java/au/csiro/fhir/export/download/UrlDownloadTemplateTest.java
+++ b/src/test/java/au/csiro/fhir/export/download/UrlDownloadTemplateTest.java
@@ -33,12 +33,17 @@ import au.csiro.utils.TimeoutUtils;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.SocketException;
 import java.net.URI;
 import java.time.Duration;
 import java.util.List;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
+import javax.annotation.Nonnull;
+import org.apache.commons.io.IOUtils;
+import org.apache.http.ConnectionClosedException;
 import org.apache.http.HttpResponse;
 import org.apache.http.ProtocolVersion;
 import org.apache.http.client.HttpClient;
@@ -68,9 +73,18 @@ class UrlDownloadTemplateTest {
   @Mock
   FileHandle fileHandle;
 
+  @Captor
+  ArgumentCaptor<HttpUriRequest> httpRequestCaptor;
+
+  /**
+   * What a caller who does not customise the download gets.
+   */
+  private static final DownloadConfig DEFAULTS = DownloadConfig.builder().build();
+
   @Test
   void testDownloadsAllUrlsSuccessfully() {
-    final UrlDownloadTemplate template = new UrlDownloadTemplate(httpClient, executorService);
+    final UrlDownloadTemplate template = new UrlDownloadTemplate(httpClient, executorService,
+        DEFAULTS);
     when(executorService.submit(eq(template.new UriDownloadTask(URI.create("http://foo.bar/file1"),
         FileHandle.ofLocal("file1"))))).thenReturn(CompletableFuture.completedFuture(3L));
     when(executorService.submit(eq(template.new UriDownloadTask(URI.create("http://foo.bar/file2"),
@@ -86,7 +100,8 @@ class UrlDownloadTemplateTest {
   @SuppressWarnings("unchecked")
   @Test
   void testThrowsTimeoutExceptionWhenTimeout() {
-    final UrlDownloadTemplate template = new UrlDownloadTemplate(httpClient, executorService);
+    final UrlDownloadTemplate template = new UrlDownloadTemplate(httpClient, executorService,
+        DEFAULTS);
     when(executorService.submit(Mockito.any(Callable.class))).thenReturn(new CompletableFuture<>());
 
     final Timeout ex = assertThrows(Timeout.class,
@@ -103,7 +118,8 @@ class UrlDownloadTemplateTest {
     final IOException downloadEx = new IOException("IO Error");
     final CompletableFuture<Long> runningFuture = new CompletableFuture<>();
 
-    final UrlDownloadTemplate template = new UrlDownloadTemplate(httpClient, executorService);
+    final UrlDownloadTemplate template = new UrlDownloadTemplate(httpClient, executorService,
+        DEFAULTS);
     when(executorService.submit(eq(template.new UriDownloadTask(URI.create("http://foo.bar/file1"),
         FileHandle.ofLocal("file1"))))).thenReturn(
         CompletableFuture.failedFuture(downloadEx));
@@ -121,10 +137,6 @@ class UrlDownloadTemplateTest {
     assertTrue(runningFuture.isCancelled());
   }
 
-
-  @Captor
-  ArgumentCaptor<HttpUriRequest> httpRequestCaptor;
-
   @Test
   void testDownloadTaskGetsTheFileOnSuccess() throws Exception {
     final InputStream responseStream = new ByteArrayInputStream(new byte[]{1, 2, 3});
@@ -133,7 +145,8 @@ class UrlDownloadTemplateTest {
         new BasicStatusLine(new ProtocolVersion("http", 1, 1), 200, "OK"));
     when(httpResponse.getEntity()).thenReturn(new InputStreamEntity(responseStream, 3));
     when(fileHandle.writeAll(Mockito.eq(responseStream))).thenReturn(7L);
-    final UrlDownloadTemplate template = new UrlDownloadTemplate(httpClient, executorService);
+    final UrlDownloadTemplate template = new UrlDownloadTemplate(httpClient, executorService,
+        DEFAULTS);
     final UrlDownloadTemplate.UriDownloadTask task = template.new UriDownloadTask(
         URI.create("http://foo.bar/file1"),
         fileHandle);
@@ -148,10 +161,262 @@ class UrlDownloadTemplateTest {
     when(httpClient.execute(Mockito.any())).thenReturn(httpResponse);
     when(httpResponse.getStatusLine()).thenReturn(
         new BasicStatusLine(new ProtocolVersion("http", 1, 1), 500, "Internal Server Error"));
-    final UrlDownloadTemplate template = new UrlDownloadTemplate(httpClient, executorService);
+    final UrlDownloadTemplate template = new UrlDownloadTemplate(httpClient, executorService,
+        DEFAULTS);
     final HttpError ex = assertThrows(HttpError.class, () -> template.new UriDownloadTask(
         URI.create("http://foo.bar/file1"),
         fileHandle).call());
     assertEquals("Failed to download: http://foo.bar/file1: [statusCode: 500]", ex.getMessage());
+  }
+
+  /**
+   * A body that yields some bytes and then fails, as one cut short mid-transfer does.
+   *
+   * @param bytesBeforeFailure the number of bytes served before the failure
+   * @param failure the failure to raise once those bytes have been served
+   * @return the body
+   */
+  @Nonnull
+  private static InputStream bodyFailingAfter(final int bytesBeforeFailure,
+      @Nonnull final IOException failure) {
+    return new InputStream() {
+
+      private int served;
+
+      @Override
+      public int read() throws IOException {
+        if (served++ < bytesBeforeFailure) {
+          return 1;
+        }
+        throw failure;
+      }
+    };
+  }
+
+  /**
+   * A body cut short the way a Content-Length delimited one is, which is the failure reported in
+   * the originating issue.
+   *
+   * @param bytesBeforeFailure the number of bytes served before the truncation
+   * @return the body
+   */
+  @Nonnull
+  private static InputStream truncatedBody(final int bytesBeforeFailure) {
+    return bodyFailingAfter(bytesBeforeFailure,
+        new ConnectionClosedException("Premature end of Content-Length delimited message body"));
+  }
+
+  /**
+   * A body that serves its bytes but fails on close, as Apache's stream does when the consumer
+   * stops before the end of the message and the remainder is drained.
+   */
+  @Nonnull
+  private static InputStream bodyFailingOnClose() {
+    return new InputStream() {
+
+      @Override
+      public int read() {
+        return 1;
+      }
+
+      @Override
+      public void close() throws IOException {
+        throw new ConnectionClosedException(
+            "Premature end of Content-Length delimited message body");
+      }
+    };
+  }
+
+  /**
+   * Copies the body through to a sink, so that a read failure surfaces from where it would in
+   * production: part way through the copy that {@code writeAll} performs.
+   */
+  private void writeAllConsumesTheBody() throws IOException {
+    when(fileHandle.writeAll(Mockito.any())).thenAnswer(invocation ->
+        IOUtils.copyLarge(invocation.getArgument(0, InputStream.class),
+            OutputStream.nullOutputStream()));
+  }
+
+  /**
+   * A response body that ends early is only discovered once it is being read, which is past the
+   * point where the HTTP client will retry for us. Exports of large resource types run to thousands
+   * of files, so without a retry here a single truncated body discards the whole export.
+   */
+  @Test
+  void testDownloadTaskRetriesAfterTruncatedBody() throws Exception {
+    when(httpClient.execute(Mockito.any())).thenReturn(httpResponse);
+    when(httpResponse.getStatusLine()).thenReturn(
+        new BasicStatusLine(new ProtocolVersion("http", 1, 1), 200, "OK"));
+    when(httpResponse.getEntity())
+        .thenReturn(new InputStreamEntity(truncatedBody(1), 3))
+        .thenReturn(new InputStreamEntity(new ByteArrayInputStream(new byte[]{1, 2, 3}), 3));
+    writeAllConsumesTheBody();
+
+    final UrlDownloadTemplate template = new UrlDownloadTemplate(httpClient, executorService,
+        DEFAULTS);
+    final long written = template.new UriDownloadTask(URI.create("http://foo.bar/file1"),
+        fileHandle).call();
+
+    assertEquals(3L, written);
+    verify(httpClient, Mockito.times(2)).execute(Mockito.any());
+  }
+
+  /**
+   * A truncation is not always discovered by a read. Apache's stream drains the rest of the message
+   * on close when the consumer stopped short of it, and raises the same failure from there, so the
+   * read side has to be recognised on close as well.
+   */
+  @Test
+  void testDownloadTaskRetriesAfterTruncationFoundOnClose() throws Exception {
+    when(httpClient.execute(Mockito.any())).thenReturn(httpResponse);
+    when(httpResponse.getStatusLine()).thenReturn(
+        new BasicStatusLine(new ProtocolVersion("http", 1, 1), 200, "OK"));
+    when(httpResponse.getEntity())
+        .thenReturn(new InputStreamEntity(bodyFailingOnClose(), 3))
+        .thenReturn(new InputStreamEntity(new ByteArrayInputStream(new byte[]{1, 2, 3}), 3));
+    // Stops short of the end of the message, leaving the remainder to be drained on close.
+    when(fileHandle.writeAll(Mockito.any())).thenAnswer(invocation -> {
+      invocation.getArgument(0, InputStream.class).read();
+      return 3L;
+    });
+
+    final UrlDownloadTemplate template = new UrlDownloadTemplate(httpClient, executorService,
+        DEFAULTS);
+    final long written = template.new UriDownloadTask(URI.create("http://foo.bar/file1"),
+        fileHandle).call();
+
+    assertEquals(3L, written);
+    verify(httpClient, Mockito.times(2)).execute(Mockito.any());
+  }
+
+  /**
+   * Retrying cannot mask a source that is genuinely broken, so the failure is still surfaced once
+   * the attempts are used up, and as the original exception rather than a wrapper.
+   */
+  @Test
+  void testDownloadTaskGivesUpAfterRepeatedFailures() throws Exception {
+    when(httpClient.execute(Mockito.any())).thenReturn(httpResponse);
+    when(httpResponse.getStatusLine()).thenReturn(
+        new BasicStatusLine(new ProtocolVersion("http", 1, 1), 200, "OK"));
+    when(httpResponse.getEntity()).thenAnswer(
+        invocation -> new InputStreamEntity(truncatedBody(1), 3));
+    writeAllConsumesTheBody();
+
+    final UrlDownloadTemplate template = new UrlDownloadTemplate(httpClient, executorService,
+        DEFAULTS);
+    final ConnectionClosedException ex = assertThrows(ConnectionClosedException.class,
+        () -> template.new UriDownloadTask(URI.create("http://foo.bar/file1"), fileHandle).call());
+
+    assertEquals("Premature end of Content-Length delimited message body", ex.getMessage());
+    verify(httpClient, Mockito.times(DEFAULTS.getMaxRetries() + 1)).execute(Mockito.any());
+  }
+
+  /**
+   * The number of retries is taken from the configuration, so that a caller can turn retrying off
+   * or widen it. Zero means the single attempt that was made before retrying existed.
+   */
+  @Test
+  void testDownloadTaskHonoursConfiguredRetries() throws Exception {
+    when(httpClient.execute(Mockito.any())).thenReturn(httpResponse);
+    when(httpResponse.getStatusLine()).thenReturn(
+        new BasicStatusLine(new ProtocolVersion("http", 1, 1), 200, "OK"));
+    when(httpResponse.getEntity()).thenAnswer(
+        invocation -> new InputStreamEntity(truncatedBody(1), 3));
+    writeAllConsumesTheBody();
+
+    final UrlDownloadTemplate template = new UrlDownloadTemplate(httpClient, executorService,
+        DownloadConfig.builder().maxRetries(0).build());
+    assertThrows(ConnectionClosedException.class,
+        () -> template.new UriDownloadTask(URI.create("http://foo.bar/file1"), fileHandle).call());
+
+    verify(httpClient, Mockito.times(1)).execute(Mockito.any());
+  }
+
+  /**
+   * A connection reset part way through is the same fault as a body that ends early, arriving as a
+   * reset rather than a close, and is equally past the point where the HTTP client will retry.
+   */
+  @Test
+  void testDownloadTaskRetriesAfterConnectionReset() throws Exception {
+    when(httpClient.execute(Mockito.any())).thenReturn(httpResponse);
+    when(httpResponse.getStatusLine()).thenReturn(
+        new BasicStatusLine(new ProtocolVersion("http", 1, 1), 200, "OK"));
+    when(httpResponse.getEntity())
+        .thenReturn(new InputStreamEntity(
+            bodyFailingAfter(1, new SocketException("Connection reset")), 3))
+        .thenReturn(new InputStreamEntity(new ByteArrayInputStream(new byte[]{1, 2, 3}), 3));
+    writeAllConsumesTheBody();
+
+    final UrlDownloadTemplate template = new UrlDownloadTemplate(httpClient, executorService,
+        DEFAULTS);
+    final long written = template.new UriDownloadTask(URI.create("http://foo.bar/file1"),
+        fileHandle).call();
+
+    assertEquals(3L, written);
+    verify(httpClient, Mockito.times(2)).execute(Mockito.any());
+  }
+
+  /**
+   * Retrying is confined to a transfer that was cut short, which is recognised by the type of the
+   * failure. Any other way of reading the body failing is not known to be transient, so repeating
+   * the transfer for it is not assumed to help.
+   */
+  @Test
+  void testDownloadTaskDoesNotRetryOtherReadFailures() throws Exception {
+    when(httpClient.execute(Mockito.any())).thenReturn(httpResponse);
+    when(httpResponse.getStatusLine()).thenReturn(
+        new BasicStatusLine(new ProtocolVersion("http", 1, 1), 200, "OK"));
+    when(httpResponse.getEntity()).thenReturn(new InputStreamEntity(
+        bodyFailingAfter(1, new IOException("Malformed response")), 3));
+    writeAllConsumesTheBody();
+
+    final UrlDownloadTemplate template = new UrlDownloadTemplate(httpClient, executorService,
+        DEFAULTS);
+    final IOException ex = assertThrows(IOException.class,
+        () -> template.new UriDownloadTask(URI.create("http://foo.bar/file1"), fileHandle).call());
+
+    assertEquals("Malformed response", ex.getMessage());
+    verify(httpClient, Mockito.times(1)).execute(Mockito.any());
+  }
+
+  /**
+   * A destination that cannot be written to is not a broken transfer. Fetching the body again
+   * cannot fix a full disk or a rejected write, so the transfer is not repeated for it.
+   */
+  @Test
+  void testDownloadTaskDoesNotRetryDestinationFailure() throws Exception {
+    when(httpClient.execute(Mockito.any())).thenReturn(httpResponse);
+    when(httpResponse.getStatusLine()).thenReturn(
+        new BasicStatusLine(new ProtocolVersion("http", 1, 1), 200, "OK"));
+    when(httpResponse.getEntity()).thenReturn(
+        new InputStreamEntity(new ByteArrayInputStream(new byte[]{1, 2, 3}), 3));
+    when(fileHandle.writeAll(Mockito.any()))
+        .thenThrow(new IOException("No space left on device"));
+
+    final UrlDownloadTemplate template = new UrlDownloadTemplate(httpClient, executorService,
+        DEFAULTS);
+    final IOException ex = assertThrows(IOException.class,
+        () -> template.new UriDownloadTask(URI.create("http://foo.bar/file1"), fileHandle).call());
+
+    assertEquals("No space left on device", ex.getMessage());
+    verify(httpClient, Mockito.times(1)).execute(Mockito.any());
+  }
+
+  /**
+   * A rejected request is a decision by the server rather than a broken transfer, so repeating it
+   * only adds load.
+   */
+  @Test
+  void testDownloadTaskDoesNotRetryHttpError() throws Exception {
+    when(httpClient.execute(Mockito.any())).thenReturn(httpResponse);
+    when(httpResponse.getStatusLine()).thenReturn(
+        new BasicStatusLine(new ProtocolVersion("http", 1, 1), 403, "Forbidden"));
+
+    final UrlDownloadTemplate template = new UrlDownloadTemplate(httpClient, executorService,
+        DEFAULTS);
+    assertThrows(HttpError.class, () -> template.new UriDownloadTask(
+        URI.create("http://foo.bar/file1"), fileHandle).call());
+
+    verify(httpClient, Mockito.times(1)).execute(Mockito.any());
   }
 }

--- a/src/test/java/au/csiro/fhir/export/download/UrlDownloadTemplateTest.java
+++ b/src/test/java/au/csiro/fhir/export/download/UrlDownloadTemplateTest.java
@@ -81,6 +81,13 @@ class UrlDownloadTemplateTest {
    */
   private static final DownloadConfig DEFAULTS = DownloadConfig.builder().build();
 
+  /**
+   * Retries are exercised without waiting out the real delay.
+   */
+  private static final DownloadConfig NO_DELAY = DownloadConfig.builder()
+      .maxRetryDelay(Duration.ZERO)
+      .build();
+
   @Test
   void testDownloadsAllUrlsSuccessfully() {
     final UrlDownloadTemplate template = new UrlDownloadTemplate(httpClient, executorService,
@@ -253,7 +260,7 @@ class UrlDownloadTemplateTest {
     writeAllConsumesTheBody();
 
     final UrlDownloadTemplate template = new UrlDownloadTemplate(httpClient, executorService,
-        DEFAULTS);
+        NO_DELAY);
     final long written = template.new UriDownloadTask(URI.create("http://foo.bar/file1"),
         fileHandle).call();
 
@@ -281,7 +288,7 @@ class UrlDownloadTemplateTest {
     });
 
     final UrlDownloadTemplate template = new UrlDownloadTemplate(httpClient, executorService,
-        DEFAULTS);
+        NO_DELAY);
     final long written = template.new UriDownloadTask(URI.create("http://foo.bar/file1"),
         fileHandle).call();
 
@@ -303,12 +310,12 @@ class UrlDownloadTemplateTest {
     writeAllConsumesTheBody();
 
     final UrlDownloadTemplate template = new UrlDownloadTemplate(httpClient, executorService,
-        DEFAULTS);
+        NO_DELAY);
     final ConnectionClosedException ex = assertThrows(ConnectionClosedException.class,
         () -> template.new UriDownloadTask(URI.create("http://foo.bar/file1"), fileHandle).call());
 
     assertEquals("Premature end of Content-Length delimited message body", ex.getMessage());
-    verify(httpClient, Mockito.times(DEFAULTS.getMaxRetries() + 1)).execute(Mockito.any());
+    verify(httpClient, Mockito.times(NO_DELAY.getMaxRetries() + 1)).execute(Mockito.any());
   }
 
   /**
@@ -325,11 +332,45 @@ class UrlDownloadTemplateTest {
     writeAllConsumesTheBody();
 
     final UrlDownloadTemplate template = new UrlDownloadTemplate(httpClient, executorService,
-        DownloadConfig.builder().maxRetries(0).build());
+        DownloadConfig.builder().maxRetries(0).maxRetryDelay(Duration.ZERO).build());
     assertThrows(ConnectionClosedException.class,
         () -> template.new UriDownloadTask(URI.create("http://foo.bar/file1"), fileHandle).call());
 
     verify(httpClient, Mockito.times(1)).execute(Mockito.any());
+  }
+
+  /**
+   * A waiting task holds one of the download threads, so the wait is bounded by the configured
+   * maximum however many attempts are made. Each delay is drawn at random from that window, so the
+   * bound is all that can be asserted - an individual delay may be anything up to it.
+   */
+  @Test
+  void testDownloadTaskKeepsRetryDelaysWithinTheConfiguredBound() throws Exception {
+    final Duration maxRetryDelay = Duration.ofMillis(200);
+    when(httpClient.execute(Mockito.any())).thenReturn(httpResponse);
+    when(httpResponse.getStatusLine()).thenReturn(
+        new BasicStatusLine(new ProtocolVersion("http", 1, 1), 200, "OK"));
+    when(httpResponse.getEntity()).thenAnswer(
+        invocation -> new InputStreamEntity(truncatedBody(1), 3));
+    writeAllConsumesTheBody();
+
+    final DownloadConfig config = DownloadConfig.builder()
+        .maxRetries(2)
+        .maxRetryDelay(maxRetryDelay)
+        .build();
+    final UrlDownloadTemplate template = new UrlDownloadTemplate(httpClient, executorService,
+        config);
+
+    final long startedAt = System.nanoTime();
+    assertThrows(ConnectionClosedException.class,
+        () -> template.new UriDownloadTask(URI.create("http://foo.bar/file1"), fileHandle).call());
+    final Duration elapsed = Duration.ofNanos(System.nanoTime() - startedAt);
+
+    // One delay precedes each retry, and none of them may exceed the maximum.
+    final Duration longestPossibleWait = maxRetryDelay.multipliedBy(config.getMaxRetries());
+    assertTrue(elapsed.compareTo(longestPossibleWait.plusSeconds(1)) < 0,
+        "Retries took " + elapsed + ", which exceeds the bound of " + longestPossibleWait);
+    verify(httpClient, Mockito.times(3)).execute(Mockito.any());
   }
 
   /**
@@ -348,7 +389,7 @@ class UrlDownloadTemplateTest {
     writeAllConsumesTheBody();
 
     final UrlDownloadTemplate template = new UrlDownloadTemplate(httpClient, executorService,
-        DEFAULTS);
+        NO_DELAY);
     final long written = template.new UriDownloadTask(URI.create("http://foo.bar/file1"),
         fileHandle).call();
 
@@ -371,7 +412,7 @@ class UrlDownloadTemplateTest {
     writeAllConsumesTheBody();
 
     final UrlDownloadTemplate template = new UrlDownloadTemplate(httpClient, executorService,
-        DEFAULTS);
+        NO_DELAY);
     final IOException ex = assertThrows(IOException.class,
         () -> template.new UriDownloadTask(URI.create("http://foo.bar/file1"), fileHandle).call());
 
@@ -394,7 +435,7 @@ class UrlDownloadTemplateTest {
         .thenThrow(new IOException("No space left on device"));
 
     final UrlDownloadTemplate template = new UrlDownloadTemplate(httpClient, executorService,
-        DEFAULTS);
+        NO_DELAY);
     final IOException ex = assertThrows(IOException.class,
         () -> template.new UriDownloadTask(URI.create("http://foo.bar/file1"), fileHandle).call());
 
@@ -413,7 +454,7 @@ class UrlDownloadTemplateTest {
         new BasicStatusLine(new ProtocolVersion("http", 1, 1), 403, "Forbidden"));
 
     final UrlDownloadTemplate template = new UrlDownloadTemplate(httpClient, executorService,
-        DEFAULTS);
+        NO_DELAY);
     assertThrows(HttpError.class, () -> template.new UriDownloadTask(
         URI.create("http://foo.bar/file1"), fileHandle).call());
 

--- a/src/test/java/au/csiro/filestore/AbstractFileStoreFactoryTest.java
+++ b/src/test/java/au/csiro/filestore/AbstractFileStoreFactoryTest.java
@@ -81,6 +81,24 @@ public abstract class AbstractFileStoreFactoryTest {
     assertEquals("Hello, world!", FileUtils.readFileToString(file, StandardCharsets.UTF_8));
   }
 
+  /**
+   * A download that is retried writes the file again from the start, so an implementation that
+   * appended, or that left the tail of a longer earlier write in place, would silently corrupt the
+   * output. The second write here is the shorter of the two, so any residue of the first shows up.
+   */
+  @Test
+  void testWriteAllReplacesExistingContent() throws IOException {
+    final File file = testRootDir.resolve("file").toFile();
+    final FileHandle handle = fileStore.get(file.getPath());
+    handle.writeAll(IOUtils.toInputStream("A partial write from a failed attempt",
+        StandardCharsets.UTF_8));
+    final long written = handle.writeAll(
+        IOUtils.toInputStream("Hello, world!", StandardCharsets.UTF_8));
+
+    assertEquals("Hello, world!", FileUtils.readFileToString(file, StandardCharsets.UTF_8));
+    assertEquals("Hello, world!".length(), written);
+  }
+
   @Test
   void testToUriWorks() {
     Assertions.assertEquals("/foo/bar", FileHandle.ofLocal("/foo/bar").getLocation());


### PR DESCRIPTION
Fixes #15.

A response body cut short mid-transfer arrives with a valid status line and headers, so the HTTP client hands it back as a success and the truncation only surfaces later, while the entity stream is being read. By then `HttpClientConfig.retryCount` and its `DefaultHttpRequestRetryHandler` are out of scope, so the failure went straight through to the caller. Because `download()` fails fast, one truncated file cancelled every other download and abandoned an export that had already been running for over an hour.

Each file now gets five attempts, and is rewritten from the start so a partial write from the previous attempt is replaced.

## Anything not known to be permanent is retried

An earlier revision of this branch enumerated the failures worth retrying — `ConnectionClosedException`, `MalformedChunkCodingException`, `SocketException` — and let everything else through. That was inverted, and `isWorthRetrying` now retries every `IOException` except those on a short list of failures known to be permanent:

| Not retried | Why |
|---|---|
| `InterruptedIOException`, `ClosedByInterruptException` | Cancellation, which must be honoured rather than retried: `download()` interrupts the outstanding tasks once any one of them has failed, and a task that swallowed that would keep issuing requests for an export already abandoned. |
| `AccessDeniedException`, `NoSuchFileException`, `FileNotFoundException` | A destination that cannot be opened at all is a misconfigured output location rather than a fault in transit, so no number of attempts will make it writable. |

The two ways of being wrong here cost wildly different amounts. Repeating a permanent failure wastes one file's transfers and then fails anyway; declining to repeat a transient one abandons an export that may represent hours of server-side processing. Listing what must not be repeated therefore errs in the cheaper direction, and it does not depend on which exception type a given transport or `FileStore` implementation happens to raise for a transfer cut short — the enumerated version was coupled to Apache's body decoders and would have silently stopped retrying under a different client.

**This is a conscious departure from #15**, which asked that *"a failure to write to the destination — a full disk, a rejected write"* not be retried. A destination that fails part way through a write is now retried, because on a file store that writes over the network — the `s3a://` and HDFS cases this library is mostly used for — such a failure is usually transient, and `FileHandle.writeAll` copies the body straight through via `IOUtils.copyLarge`, so reads and writes interleave inside one call and emerge indistinguishably as an `IOException`. Only the unopenable-destination case, which can be told apart reliably, is excluded. If wasting a large re-transfer against a genuinely full local disk matters more than recovering a transient remote write, this is the decision to revisit.

Two failures remain outside the retry loop by construction:

- **A non-200 response** is the server declining rather than a transfer breaking, and repeating it would only add load. `HttpError` is not an `IOException`, so it falls outside the catch.
- **A request-level failure** is left to the HTTP client, which already retries it.

## The delay is bounded and jittered, not exponential

Downloads run concurrently against a single endpoint, so a server shedding connections cuts several of them short at once and they come back together. Each retry waits a random interval drawn from `[0, maxRetryDelay]`.

Randomising is what separates downloads that failed together — growing the delay would not, since they would grow in step. The wait is bounded rather than exponential for two reasons specific to this design: a waiting task holds one of the `maxConcurrentDownloads` pool threads, so a long delay costs download throughput directly; and it spends the export's overall timeout budget, which the download is already racing. A transfer cut short is usually an intermediary dropping the connection rather than contention this client is adding to, so backing off further each time buys little.

## Configuration

The retry count and delay live in a new `DownloadConfig`, alongside `AsyncConfig` and `HttpClientConfig` on the builder. This is a public API addition.

`maxRetries` counts retries, with `0` disabling them, so it matches the convention the other two already use:

| | Retries on | Off |
|---|---|---|
| `HttpClientConfig.retryCount` | `IOException` before the response is handed over | `retryEnabled = false` |
| `AsyncConfig.maxTransientErrors` | transient `HttpError` while polling status | `0` |
| `DownloadConfig.maxRetries` | any `IOException` not known to be permanent, per file | `0` |

Both settings are validated where they are configured rather than where they are used: a negative delay reaches `Thread.sleep` and a negative retry count is counted down, and neither should surface part way through an export.

`UrlDownloadTemplate` gains a new three-argument constructor that also takes a `DownloadConfig`; the existing two-argument constructor is kept and now delegates to it with a default `DownloadConfig`, so no existing caller is broken. `BulkExportClient` calls the three-argument constructor directly, passing its own config, and the sibling `BulkExportTemplate` likewise requires its `AsyncConfig`.

## Testing

The two retry tests written alongside the original fix had to be rewritten, and that is the substance of the change rather than incidental churn: they mocked `writeAll` to throw, simulating a read fault by faking a write fault, so they could never have distinguished the two cases. They now fail from a stream that dies mid-body, with `writeAll` genuinely consuming it.

Tests pin each side of the retry policy explicitly, so the boundary is asserted rather than assumed: a truncated Content-Length body, a truncation discovered on close, a TLS truncation, a connection reset, an unrecognised read failure and a destination failure part way through a write are all retried (`testDownloadTaskRetriesAfterTruncatedBody`, `…AfterTruncationFoundOnClose`, `…AfterTlsTruncation`, `…AfterConnectionReset`, `…RetriesUnrecognisedReadFailures`, `…RetriesDestinationFailureMidWrite`); an unwritable destination, an `HttpError` and a cancellation are not (`…DoesNotRetryUnwritableDestination`, `…DoesNotRetryHttpError`, `…StopsWhenCancelled`). `…GivesUpAfterRepeatedFailures` and `…HonoursConfiguredRetries` cover the attempt count, and `…KeepsRetryDelaysWithinTheConfiguredBound` the delay. Jitter means only the upper bound can be asserted — an individual delay may legitimately be near zero.

118 tests pass.

## Notes

Also corrects the `retryCount` Javadoc, which described it as retrying terminology requests — apparently carried over from another codebase.

This work was previously part of #13. It is independent of the filesystem fix there and touches disjoint files.

