### PR TITLE
Release 1.1.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ tmp/
 .classpath
 .project
 .settings/
+.factorypath
 
 # IDEA
 .idea

--- a/README.md
+++ b/README.md
@@ -270,6 +270,8 @@ or by providing a customised sub-configuration objects.
   transient errors, max pooling delay)
 - `HttpClientConfig` - customise the HTTP client configuration (e.g. retry
   count, socket timeout)
+- `DownloadConfig` - customise how a download whose transfer is cut short
+  mid-body is retried (e.g. max retries)
 
 ```java
 // The FHIR endpoint URL for https://bulk-data.smarthealthit.org/.
@@ -290,6 +292,11 @@ final HttpClientConfig httpClientConfig = HttpClientConfig.builder()
         .socketTimeout(10_000)
         .build();
 
+// Create a customised download configuration.
+final DownloadConfig downloadConfig = DownloadConfig.builder()
+        .maxRetries(9) // Retries per file, on top of the first attempt.
+        .build();
+
 // Build the client with a system level and customised run-time configuration.
 final BulkExportResult result = BulkExportClient.systemBuilder()
         .withFhirEndpointUrl(fhirEndpointUrl)
@@ -298,6 +305,7 @@ final BulkExportResult result = BulkExportClient.systemBuilder()
         .withTimeout(Duration.ofMinutes(60))
         .withAsyncConfig(asyncConfig)
         .withHttpClientConfig(httpClientConfig)
+        .withDownloadConfig(downloadConfig)
         .build()
         .export();
 ```

--- a/README.md
+++ b/README.md
@@ -270,8 +270,8 @@ or by providing a customised sub-configuration objects.
   transient errors, max pooling delay)
 - `HttpClientConfig` - customise the HTTP client configuration (e.g. retry
   count, socket timeout)
-- `DownloadConfig` - customise how a download whose transfer is cut short
-  mid-body is retried (e.g. max retries, max retry delay)
+- `DownloadConfig` - customise how a failed download of an output file is
+  retried (e.g. max retries, max retry delay)
 
 ```java
 // The FHIR endpoint URL for https://bulk-data.smarthealthit.org/.

--- a/README.md
+++ b/README.md
@@ -271,7 +271,7 @@ or by providing a customised sub-configuration objects.
 - `HttpClientConfig` - customise the HTTP client configuration (e.g. retry
   count, socket timeout)
 - `DownloadConfig` - customise how a download whose transfer is cut short
-  mid-body is retried (e.g. max retries)
+  mid-body is retried (e.g. max retries, max retry delay)
 
 ```java
 // The FHIR endpoint URL for https://bulk-data.smarthealthit.org/.
@@ -295,6 +295,7 @@ final HttpClientConfig httpClientConfig = HttpClientConfig.builder()
 // Create a customised download configuration.
 final DownloadConfig downloadConfig = DownloadConfig.builder()
         .maxRetries(9) // Retries per file, on top of the first attempt.
+        .maxRetryDelay(Duration.ofSeconds(5)) // Each delay is random, up to this.
         .build();
 
 // Build the client with a system level and customised run-time configuration.

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
   <modelVersion>4.0.0</modelVersion>
 
   <groupId>au.csiro.fhir</groupId>
-  <version>1.0.4</version>
+  <version>1.0.5-SNAPSHOT</version>
   <artifactId>bulk-export</artifactId>
   <packaging>jar</packaging>
 

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
   <modelVersion>4.0.0</modelVersion>
 
   <groupId>au.csiro.fhir</groupId>
-  <version>1.0.4-SNAPSHOT</version>
+  <version>1.1.0-SNAPSHOT</version>
   <artifactId>bulk-export</artifactId>
   <packaging>jar</packaging>
 

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
   <modelVersion>4.0.0</modelVersion>
 
   <groupId>au.csiro.fhir</groupId>
-  <version>1.0.4-SNAPSHOT</version>
+  <version>1.0.4</version>
   <artifactId>bulk-export</artifactId>
   <packaging>jar</packaging>
 

--- a/src/main/java/au/csiro/fhir/export/BulkExportClient.java
+++ b/src/main/java/au/csiro/fhir/export/BulkExportClient.java
@@ -84,6 +84,8 @@ import org.hibernate.validator.constraints.URL;
  * A client for the FHIR Bulk Data Export API.
  *
  * @see <a href="https://build.fhir.org/ig/HL7/bulk-data/export.html">FHIR Bulk Export</a>
+ * @author Piotr Szul
+ * @author John Grimes
  */
 @Value
 @Slf4j

--- a/src/main/java/au/csiro/fhir/export/BulkExportClient.java
+++ b/src/main/java/au/csiro/fhir/export/BulkExportClient.java
@@ -51,6 +51,7 @@ import com.google.common.collect.Streams;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.net.URI;
+import java.nio.file.FileSystemNotFoundException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.time.Duration;
@@ -456,7 +457,9 @@ public class BulkExportClient {
         final Path parentPath = Paths.get(parentUri).toAbsolutePath().normalize();
         final Path childPath = Paths.get(childUri).toAbsolutePath().normalize();
         return childPath.startsWith(parentPath);
-      } catch (final Exception e) {
+      } catch (final IllegalArgumentException | FileSystemNotFoundException e) {
+        log.debug("Could not resolve file URI for descendant check; "
+            + "treating as non-descendant. parent={}, child={}", parentUri, childUri, e);
         return false;
       }
     }

--- a/src/main/java/au/csiro/fhir/export/BulkExportClient.java
+++ b/src/main/java/au/csiro/fhir/export/BulkExportClient.java
@@ -24,6 +24,7 @@ import au.csiro.fhir.auth.AuthConfig;
 import au.csiro.fhir.auth.SMARTTokenCredentialFactory;
 import au.csiro.fhir.auth.TokenCredentialFactory;
 import au.csiro.fhir.export.BulkExportResult.FileResult;
+import au.csiro.fhir.export.download.DownloadConfig;
 import au.csiro.fhir.export.download.UrlDownloadTemplate;
 import au.csiro.fhir.export.download.UrlDownloadTemplate.UrlDownloadEntry;
 import au.csiro.fhir.export.ws.AssociatedData;
@@ -219,6 +220,14 @@ public class BulkExportClient {
   @Builder.Default
   AsyncConfig asyncConfig = AsyncConfig.builder().build();
 
+  /**
+   * The configuration for the download of the output files.
+   */
+  @Nonnull
+  @Valid
+  @Builder.Default
+  DownloadConfig downloadConfig = DownloadConfig.builder().build();
+
 
   /**
    * The configuration for the authentication.
@@ -307,7 +316,7 @@ public class BulkExportClient {
           new BulkExportAsyncService(httpClient, URI.create(fhirEndpointUrl)),
           asyncConfig);
       final UrlDownloadTemplate downloadTemplate = new UrlDownloadTemplate(httpClient,
-          executorServiceResource.getExecutorService());
+          executorServiceResource.getExecutorService(), downloadConfig);
 
       final BulkExportResult result = doExport(fileStore, bulkExportTemplate, downloadTemplate);
       log.info("Export successful: {}", result);

--- a/src/main/java/au/csiro/fhir/export/BulkExportClient.java
+++ b/src/main/java/au/csiro/fhir/export/BulkExportClient.java
@@ -399,6 +399,11 @@ public class BulkExportClient {
         .flatMap(entry -> IntStream.range(0, entry.getValue().size())
             .mapToObj(index -> {
                 final String fileName = toFileName(entry.getKey(), index, extension);
+                if (isAbsoluteFileName(fileName)) {
+                  throw new BulkExportException(
+                      "Manifest file type resolves to an absolute path: "
+                          + entry.getKey());
+                }
                 if (fileName.indexOf('/') >= 0 || fileName.indexOf('\\') >= 0) {
                   throw new BulkExportException(
                       "Manifest file type contains invalid path separators: "
@@ -412,6 +417,17 @@ public class BulkExportClient {
                 );
             })
         ).collect(Collectors.toUnmodifiableList());
+  }
+
+  private static boolean isAbsoluteFileName(@Nonnull final String fileName) {
+    // A platform-independent check for absolute paths. Wrapped in a try/catch because on some
+    // platforms (notably Windows) certain characters cause Paths.get to throw; in that case we
+    // conservatively treat the input as unsafe.
+    try {
+      return Paths.get(fileName).isAbsolute();
+    } catch (final java.nio.file.InvalidPathException e) {
+      return true;
+    }
   }
 
   private static void validateDescendant(@Nonnull final FileHandle parent,

--- a/src/main/java/au/csiro/fhir/export/BulkExportClient.java
+++ b/src/main/java/au/csiro/fhir/export/BulkExportClient.java
@@ -58,6 +58,7 @@ import java.time.Instant;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.Executors;
 import java.util.stream.Collectors;
@@ -435,12 +436,26 @@ public class BulkExportClient {
         return false;
       }
     }
-    // For non-file schemes, use a conservative string prefix check on normalised URIs.
-    String parentStr = parentUri.normalize().toString();
-    if (!parentStr.endsWith("/")) {
-      parentStr = parentStr + "/";
+    // For non-file schemes, compare the structural components of the URI (scheme, authority and
+    // path) and ignore any query or fragment that the URI may carry.
+    if (!Objects.equals(parentUri.getScheme(), childUri.getScheme())
+        || !Objects.equals(parentUri.getAuthority(), childUri.getAuthority())) {
+      return false;
     }
-    return childUri.normalize().toString().startsWith(parentStr);
+    final String parentPath = normalisePath(parentUri.getPath());
+    final String childPath = normalisePath(childUri.getPath());
+    final String parentDir = parentPath.endsWith("/") ? parentPath : parentPath + "/";
+    return childPath.startsWith(parentDir);
+  }
+
+  @Nonnull
+  private static String normalisePath(@Nullable final String rawPath) {
+    if (rawPath == null || rawPath.isEmpty()) {
+      return "/";
+    }
+    // Use a synthetic file: URI to leverage URI normalisation, which collapses dot-segments
+    // without altering the path's structure.
+    return URI.create("file://" + rawPath).normalize().getPath();
   }
 
   @Nonnull

--- a/src/main/java/au/csiro/fhir/export/BulkExportClient.java
+++ b/src/main/java/au/csiro/fhir/export/BulkExportClient.java
@@ -51,6 +51,8 @@ import com.google.common.collect.Streams;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.net.URI;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.LinkedHashMap;
@@ -394,12 +396,51 @@ public class BulkExportClient {
     final String extension = extensionFromFormat(outputFormat, outputExtension);
     return urlsByType.entrySet().stream()
         .flatMap(entry -> IntStream.range(0, entry.getValue().size())
-            .mapToObj(index -> new UrlDownloadEntry(
+            .mapToObj(index -> {
+                final String fileName = toFileName(entry.getKey(), index, extension);
+                if (fileName.indexOf('/') >= 0 || fileName.indexOf('\\') >= 0) {
+                  throw new BulkExportException(
+                      "Manifest file type contains invalid path separators: "
+                          + entry.getKey());
+                }
+                final FileHandle destinationFile = destinationDir.child(fileName);
+                validateDescendant(destinationDir, destinationFile);
+                return new UrlDownloadEntry(
                     URI.create(entry.getValue().get(index)),
-                    destinationDir.child(toFileName(entry.getKey(), index, extension))
-                )
-            )
+                    destinationFile
+                );
+            })
         ).collect(Collectors.toUnmodifiableList());
+  }
+
+  private static void validateDescendant(@Nonnull final FileHandle parent,
+      @Nonnull final FileHandle child) {
+    if (!isDescendant(parent, child)) {
+      throw new BulkExportException(
+          "Manifest file type results in a destination outside the output directory: "
+              + child.getLocation());
+    }
+  }
+
+  private static boolean isDescendant(@Nonnull final FileHandle parent,
+      @Nonnull final FileHandle child) {
+    final URI parentUri = parent.toUri();
+    final URI childUri = child.toUri();
+    if ("file".equals(parentUri.getScheme()) && "file".equals(childUri.getScheme())) {
+      try {
+        final Path parentPath = Paths.get(parentUri).toAbsolutePath().normalize();
+        final Path childPath = Paths.get(childUri).toAbsolutePath().normalize();
+        return childPath.startsWith(parentPath);
+      } catch (final Exception e) {
+        return false;
+      }
+    }
+    // For non-file schemes, use a conservative string prefix check on normalised URIs.
+    String parentStr = parentUri.normalize().toString();
+    if (!parentStr.endsWith("/")) {
+      parentStr = parentStr + "/";
+    }
+    return childUri.normalize().toString().startsWith(parentStr);
   }
 
   @Nonnull

--- a/src/main/java/au/csiro/fhir/export/BulkExportClient.java
+++ b/src/main/java/au/csiro/fhir/export/BulkExportClient.java
@@ -51,15 +51,11 @@ import com.google.common.collect.Streams;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.net.URI;
-import java.nio.file.FileSystemNotFoundException;
-import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.Executors;
 import java.util.stream.Collectors;
@@ -398,91 +394,16 @@ public class BulkExportClient {
             mapping(BulkExportResponse.FileItem::getUrl, toList())));
 
     final String extension = extensionFromFormat(outputFormat, outputExtension);
+    // The manifest is validated in BulkExportTemplate before it reaches here, which guarantees
+    // that each type is a FHIR resource type name and so cannot escape the destination directory.
     return urlsByType.entrySet().stream()
         .flatMap(entry -> IntStream.range(0, entry.getValue().size())
-            .mapToObj(index -> {
-                final String fileName = toFileName(entry.getKey(), index, extension);
-                // Three layered checks defend against a malicious manifest type. The first two
-                // catch the common attack shapes (absolute paths and embedded separators)
-                // early so that failures point at the specific problem in the manifest. The
-                // descendant check is the ultimate safety net for any escape that slips
-                // through, including via FileHandle implementations whose child() resolution
-                // differs from naive concatenation.
-                if (isAbsoluteFileName(fileName)) {
-                  throw new BulkExportException(
-                      "Manifest file type resolves to an absolute path: "
-                          + entry.getKey());
-                }
-                if (fileName.indexOf('/') >= 0 || fileName.indexOf('\\') >= 0) {
-                  throw new BulkExportException(
-                      "Manifest file type contains invalid path separators: "
-                          + entry.getKey());
-                }
-                final FileHandle destinationFile = destinationDir.child(fileName);
-                validateDescendant(destinationDir, destinationFile);
-                return new UrlDownloadEntry(
+            .mapToObj(index -> new UrlDownloadEntry(
                     URI.create(entry.getValue().get(index)),
-                    destinationFile
-                );
-            })
+                    destinationDir.child(toFileName(entry.getKey(), index, extension))
+                )
+            )
         ).collect(Collectors.toUnmodifiableList());
-  }
-
-  private static boolean isAbsoluteFileName(@Nonnull final String fileName) {
-    // A platform-independent check for absolute paths. Wrapped in a try/catch because on some
-    // platforms (notably Windows) certain characters cause Paths.get to throw; in that case we
-    // conservatively treat the input as unsafe.
-    try {
-      return Paths.get(fileName).isAbsolute();
-    } catch (final java.nio.file.InvalidPathException e) {
-      return true;
-    }
-  }
-
-  private static void validateDescendant(@Nonnull final FileHandle parent,
-      @Nonnull final FileHandle child) {
-    if (!isDescendant(parent, child)) {
-      throw new BulkExportException(
-          "Manifest file type results in a destination outside the output directory: "
-              + child.getLocation());
-    }
-  }
-
-  private static boolean isDescendant(@Nonnull final FileHandle parent,
-      @Nonnull final FileHandle child) {
-    final URI parentUri = parent.toUri();
-    final URI childUri = child.toUri();
-    if ("file".equals(parentUri.getScheme()) && "file".equals(childUri.getScheme())) {
-      try {
-        final Path parentPath = Paths.get(parentUri).toAbsolutePath().normalize();
-        final Path childPath = Paths.get(childUri).toAbsolutePath().normalize();
-        return childPath.startsWith(parentPath);
-      } catch (final IllegalArgumentException | FileSystemNotFoundException e) {
-        log.debug("Could not resolve file URI for descendant check; "
-            + "treating as non-descendant. parent={}, child={}", parentUri, childUri, e);
-        return false;
-      }
-    }
-    // For non-file schemes, compare the structural components of the URI (scheme, authority and
-    // path) and ignore any query or fragment that the URI may carry.
-    if (!Objects.equals(parentUri.getScheme(), childUri.getScheme())
-        || !Objects.equals(parentUri.getAuthority(), childUri.getAuthority())) {
-      return false;
-    }
-    final String parentPath = normalisePath(parentUri.getPath());
-    final String childPath = normalisePath(childUri.getPath());
-    final String parentDir = parentPath.endsWith("/") ? parentPath : parentPath + "/";
-    return childPath.startsWith(parentDir);
-  }
-
-  @Nonnull
-  private static String normalisePath(@Nullable final String rawPath) {
-    if (rawPath == null || rawPath.isEmpty()) {
-      return "/";
-    }
-    // Use a synthetic file: URI to leverage URI normalisation, which collapses dot-segments
-    // without altering the path's structure.
-    return URI.create("file://" + rawPath).normalize().getPath();
   }
 
   @Nonnull

--- a/src/main/java/au/csiro/fhir/export/BulkExportClient.java
+++ b/src/main/java/au/csiro/fhir/export/BulkExportClient.java
@@ -401,6 +401,12 @@ public class BulkExportClient {
         .flatMap(entry -> IntStream.range(0, entry.getValue().size())
             .mapToObj(index -> {
                 final String fileName = toFileName(entry.getKey(), index, extension);
+                // Three layered checks defend against a malicious manifest type. The first two
+                // catch the common attack shapes (absolute paths and embedded separators)
+                // early so that failures point at the specific problem in the manifest. The
+                // descendant check is the ultimate safety net for any escape that slips
+                // through, including via FileHandle implementations whose child() resolution
+                // differs from naive concatenation.
                 if (isAbsoluteFileName(fileName)) {
                   throw new BulkExportException(
                       "Manifest file type resolves to an absolute path: "

--- a/src/main/java/au/csiro/fhir/export/BulkExportException.java
+++ b/src/main/java/au/csiro/fhir/export/BulkExportException.java
@@ -186,7 +186,7 @@ public class BulkExportException extends RuntimeException {
      * @param message the detail message.
      * @param cause the cause.
      */
-    public DownloadError(@Nonnull final String message, final Throwable cause) {
+    public DownloadError(@Nonnull final String message, @Nonnull final Throwable cause) {
       super(message, cause);
     }
   }

--- a/src/main/java/au/csiro/fhir/export/BulkExportException.java
+++ b/src/main/java/au/csiro/fhir/export/BulkExportException.java
@@ -206,5 +206,15 @@ public class BulkExportException extends RuntimeException {
     public ProtocolError(@Nonnull final String message) {
       super(message);
     }
+
+    /**
+     * Constructs a new exception with the specified detail message and cause
+     *
+     * @param message the detailed message
+     * @param cause the cause of the exception
+     */
+    public ProtocolError(@Nonnull final String message, @Nonnull final Throwable cause) {
+      super(message, cause);
+    }
   }
 }

--- a/src/main/java/au/csiro/fhir/export/download/DownloadConfig.java
+++ b/src/main/java/au/csiro/fhir/export/download/DownloadConfig.java
@@ -47,8 +47,8 @@ public class DownloadConfig {
    */
   @Nonnull
   @Builder.Default
-  // The default message for this constraint is an EL template, which is left uninterpolated
-  // without an EL implementation on the classpath, so it is spelled out here instead.
+  // The default message for this constraint is an EL template, and ValidationUtils interpolates
+  // with a ParameterMessageInterpolator, which does not evaluate EL, so it is spelled out here.
   @DurationMin(nanos = 0, message = "must not be negative")
   Duration maxRetryDelay = Duration.ofSeconds(2);
 }

--- a/src/main/java/au/csiro/fhir/export/download/DownloadConfig.java
+++ b/src/main/java/au/csiro/fhir/export/download/DownloadConfig.java
@@ -17,9 +17,12 @@
 
 package au.csiro.fhir.export.download;
 
+import java.time.Duration;
+import javax.annotation.Nonnull;
 import jakarta.validation.constraints.Min;
 import lombok.Builder;
 import lombok.Value;
+import org.hibernate.validator.constraints.time.DurationMin;
 
 /**
  * Configuration relating to the download of the output files of an export.
@@ -35,4 +38,16 @@ public class DownloadConfig {
   @Builder.Default
   @Min(0)
   int maxRetries = 4;
+
+  /**
+   * The longest that a retry of a file is delayed. Each delay is a random value up to this, so
+   * that downloads cut short together do not all retry at the same moment. Zero retries
+   * immediately.
+   */
+  @Nonnull
+  @Builder.Default
+  // The default message for this constraint is an EL template, which is left uninterpolated
+  // without an EL implementation on the classpath, so it is spelled out here instead.
+  @DurationMin(nanos = 0, message = "must not be negative")
+  Duration maxRetryDelay = Duration.ofSeconds(2);
 }

--- a/src/main/java/au/csiro/fhir/export/download/DownloadConfig.java
+++ b/src/main/java/au/csiro/fhir/export/download/DownloadConfig.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2023 Commonwealth Scientific and Industrial Research
+ * Organisation (CSIRO) ABN 41 687 119 230.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package au.csiro.fhir.export.download;
+
+import jakarta.validation.constraints.Min;
+import lombok.Builder;
+import lombok.Value;
+
+/**
+ * Configuration relating to the download of the output files of an export.
+ */
+@Value
+@Builder
+public class DownloadConfig {
+
+  /**
+   * The number of times a single file is retried after its first attempt fails. Zero disables
+   * retrying, so the default of four allows five attempts in total.
+   */
+  @Builder.Default
+  @Min(0)
+  int maxRetries = 4;
+}

--- a/src/main/java/au/csiro/fhir/export/download/DownloadConfig.java
+++ b/src/main/java/au/csiro/fhir/export/download/DownloadConfig.java
@@ -32,8 +32,9 @@ import org.hibernate.validator.constraints.time.DurationMin;
 public class DownloadConfig {
 
   /**
-   * The number of times a single file is retried after its first attempt fails. Zero disables
-   * retrying, so the default of four allows five attempts in total.
+   * The number of times a single file is retried after its first attempt fails, for a failure that
+   * is not known to be permanent. Zero disables retrying, so the default of four allows five
+   * attempts in total.
    */
   @Builder.Default
   @Min(0)

--- a/src/main/java/au/csiro/fhir/export/download/UrlDownloadTemplate.java
+++ b/src/main/java/au/csiro/fhir/export/download/UrlDownloadTemplate.java
@@ -163,8 +163,9 @@ public class UrlDownloadTemplate {
     public Long call() throws Exception {
       // A body that ends early is only discovered while it is being read, which is after the HTTP
       // client has stopped considering the request retryable. Retry here so that one interrupted
-      // transfer does not discard an export that may run to thousands of files. The file is
-      // rewritten from the start, so a partial write from the previous attempt is replaced.
+      // transfer does not discard an export that may run to thousands of files. A partial write
+      // from the previous attempt is replaced, since writeAll requires the file to be written from
+      // the start.
       //
       // Every failure of an attempt is retried unless it is known to be permanent. A rejected
       // request is excluded by construction, since HttpError is not an IOException.

--- a/src/main/java/au/csiro/fhir/export/download/UrlDownloadTemplate.java
+++ b/src/main/java/au/csiro/fhir/export/download/UrlDownloadTemplate.java
@@ -39,6 +39,7 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
@@ -121,6 +122,22 @@ public class UrlDownloadTemplate {
         || e instanceof SocketException;
   }
 
+  /**
+   * How long to wait before the next attempt at a file. Downloads run concurrently against a
+   * single endpoint, so a fault that cuts several of them short at once would otherwise have them
+   * all retry in step. Spreading each one at random across the configured window breaks that up,
+   * and holds the wait to a bound, since a waiting task occupies one of the download threads.
+   *
+   * @return a delay of at most the configured maximum
+   */
+  @Nonnull
+  private Duration nextRetryDelay() {
+    final long maxMillis = config.getMaxRetryDelay().toMillis();
+    return maxMillis > 0
+           ? Duration.ofMillis(ThreadLocalRandom.current().nextLong(maxMillis + 1))
+           : Duration.ZERO;
+  }
+
   @Value
   class UriDownloadTask implements Callable<Long> {
 
@@ -153,8 +170,10 @@ public class UrlDownloadTemplate {
             log.error("Failed to download {} after {} attempts", source, attempt);
             throw e;
           }
-          log.warn("Download of {} failed on attempt {} of {} ({}), retrying", source,
-              attempt, maxAttempts, e.getMessage());
+          final Duration delay = nextRetryDelay();
+          log.warn("Download of {} failed on attempt {} of {} ({}), retrying in {}", source,
+              attempt, maxAttempts, e.getMessage(), delay);
+          TimeUnit.MILLISECONDS.sleep(delay.toMillis());
         }
       }
     }

--- a/src/main/java/au/csiro/fhir/export/download/UrlDownloadTemplate.java
+++ b/src/main/java/au/csiro/fhir/export/download/UrlDownloadTemplate.java
@@ -26,7 +26,9 @@ import au.csiro.fhir.export.BulkExportException.DownloadError;
 import au.csiro.fhir.export.BulkExportException.HttpError;
 import au.csiro.fhir.export.BulkExportException.Timeout;
 import au.csiro.filestore.FileStore.FileHandle;
+import java.io.IOException;
 import java.io.InputStream;
+import java.net.SocketException;
 import java.net.URI;
 import java.time.Duration;
 import java.time.Instant;
@@ -42,7 +44,9 @@ import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
 import lombok.Value;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.http.ConnectionClosedException;
 import org.apache.http.HttpResponse;
+import org.apache.http.MalformedChunkCodingException;
 import org.apache.http.client.HttpClient;
 import org.apache.http.client.methods.HttpGet;
 
@@ -50,8 +54,9 @@ import org.apache.http.client.methods.HttpGet;
  * A template class for concurrent download of multiple URLs into a file store. The file store can
  * be any concrete implementation of the {@link FileStore} abstraction.
  * <p>
- * This implementation fails fast: all the downloads are terminated on the first failure in any of
- * the downloads.
+ * A download whose transfer is cut short mid-body is retried, since that is a transient fault.
+ * Once a single download has used up its attempts this implementation fails fast: all the
+ * remaining downloads are terminated.
  * <p>
  * No cleanup is performed on failure - partial results may be left for some of the URLs.
  */
@@ -92,6 +97,30 @@ public class UrlDownloadTemplate {
   @Nonnull
   ExecutorService executorService;
 
+  /**
+   * The configuration governing how a failed download is retried.
+   */
+  @Nonnull
+  DownloadConfig config;
+
+  /**
+   * Recognises a transfer that was cut short before the message was complete. Apache's body
+   * decoders raise these when the connection closes or is reset part way through, and no other
+   * part of a download does, so a broken transfer is told apart from a destination that cannot be
+   * written to by the type of the failure rather than by where it was thrown.
+   *
+   * @param e the failure that ended the attempt
+   * @return true if the transfer was cut short, and so is worth repeating
+   */
+  private static boolean isTruncatedBody(@Nonnull final IOException e) {
+    // ConnectionClosedException is a Content-Length delimited body ending early, and
+    // MalformedChunkCodingException, with its TruncatedChunkException subclass, the chunked
+    // equivalent. A SocketException is the same fault arriving as a reset rather than a close.
+    return e instanceof ConnectionClosedException
+        || e instanceof MalformedChunkCodingException
+        || e instanceof SocketException;
+  }
+
   @Value
   class UriDownloadTask implements Callable<Long> {
 
@@ -103,9 +132,46 @@ public class UrlDownloadTemplate {
 
     @Override
     public Long call() throws Exception {
+      // A body that ends early is only discovered while it is being read, which is after the HTTP
+      // client has stopped considering the request retryable. Retry here so that one interrupted
+      // transfer does not discard an export that may run to thousands of files. The file is
+      // rewritten from the start, so a partial write from the previous attempt is replaced.
+      //
+      // Only a transfer cut short is retried. A destination that cannot be written to will not be
+      // fixed by fetching the body again, and re-downloading a large file to meet the same full
+      // disk or rejected write wastes the transfer. Failures of the request itself are left to the
+      // HTTP client, which retries them already.
+      final int maxAttempts = config.getMaxRetries() + 1;
+      for (int attempt = 1; ; attempt++) {
+        try {
+          return attemptDownload();
+        } catch (final IOException e) {
+          if (!isTruncatedBody(e)) {
+            throw e;
+          }
+          if (attempt >= maxAttempts) {
+            log.error("Failed to download {} after {} attempts", source, attempt);
+            throw e;
+          }
+          log.warn("Download of {} failed on attempt {} of {} ({}), retrying", source,
+              attempt, maxAttempts, e.getMessage());
+        }
+      }
+    }
+
+    /**
+     * Performs a single download attempt.
+     *
+     * @return the number of bytes written
+     * @throws IOException if the body ends before it has been read in full, the request fails, or
+     * the destination cannot be written to
+     */
+    private long attemptDownload() throws IOException {
       log.debug("Starting download from:  {}  to: {}", source, destination);
       final HttpResponse result = httpClient.execute(new HttpGet(source));
       if (result.getStatusLine().getStatusCode() != 200) {
+        // The server has rejected the request rather than failed to deliver it, so repeating it
+        // would only add load. HttpError is not an IOException and so is not retried.
         log.error("Failed to download: {}. Status: {}", source, result.getStatusLine());
         throw new HttpError(
             "Failed to download: " + source, result.getStatusLine().getStatusCode());
@@ -125,11 +191,13 @@ public class UrlDownloadTemplate {
    * externally).
    * @param executorService the executor service to use for concurrent downloads (its life cycle
    * should be managed externally).
+   * @param config the configuration governing how a failed download is retried.
    */
   public UrlDownloadTemplate(@Nonnull final HttpClient httpClient,
-      @Nonnull final ExecutorService executorService) {
+      @Nonnull final ExecutorService executorService, @Nonnull final DownloadConfig config) {
     this.httpClient = httpClient;
     this.executorService = executorService;
+    this.config = config;
   }
 
   /**

--- a/src/main/java/au/csiro/fhir/export/download/UrlDownloadTemplate.java
+++ b/src/main/java/au/csiro/fhir/export/download/UrlDownloadTemplate.java
@@ -237,6 +237,20 @@ public class UrlDownloadTemplate {
   }
 
   /**
+   * Creates a new instance of the template with the default download configuration, which retries a
+   * failed download four times.
+   *
+   * @param httpClient the HTTP client to use for downloading (its life cycle should be managed
+   * externally).
+   * @param executorService the executor service to use for concurrent downloads (its life cycle
+   * should be managed externally).
+   */
+  public UrlDownloadTemplate(@Nonnull final HttpClient httpClient,
+      @Nonnull final ExecutorService executorService) {
+    this(httpClient, executorService, DownloadConfig.builder().build());
+  }
+
+  /**
    * Downloads the given URLs concurrently to provided destinations in a
    * {@link FileStore}.
    *

--- a/src/main/java/au/csiro/fhir/export/download/UrlDownloadTemplate.java
+++ b/src/main/java/au/csiro/fhir/export/download/UrlDownloadTemplate.java
@@ -26,10 +26,14 @@ import au.csiro.fhir.export.BulkExportException.DownloadError;
 import au.csiro.fhir.export.BulkExportException.HttpError;
 import au.csiro.fhir.export.BulkExportException.Timeout;
 import au.csiro.filestore.FileStore.FileHandle;
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
-import java.net.SocketException;
+import java.io.InterruptedIOException;
 import java.net.URI;
+import java.nio.channels.ClosedByInterruptException;
+import java.nio.file.AccessDeniedException;
+import java.nio.file.NoSuchFileException;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.Collection;
@@ -45,9 +49,7 @@ import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
 import lombok.Value;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.http.ConnectionClosedException;
 import org.apache.http.HttpResponse;
-import org.apache.http.MalformedChunkCodingException;
 import org.apache.http.client.HttpClient;
 import org.apache.http.client.methods.HttpGet;
 
@@ -55,9 +57,9 @@ import org.apache.http.client.methods.HttpGet;
  * A template class for concurrent download of multiple URLs into a file store. The file store can
  * be any concrete implementation of the {@link FileStore} abstraction.
  * <p>
- * A download whose transfer is cut short mid-body is retried, since that is a transient fault.
- * Once a single download has used up its attempts this implementation fails fast: all the
- * remaining downloads are terminated.
+ * A download that fails is retried, unless the failure is one that is known to be permanent. Once a
+ * single download has used up its attempts this implementation fails fast: all the remaining
+ * downloads are terminated.
  * <p>
  * No cleanup is performed on failure - partial results may be left for some of the URLs.
  */
@@ -105,21 +107,31 @@ public class UrlDownloadTemplate {
   DownloadConfig config;
 
   /**
-   * Recognises a transfer that was cut short before the message was complete. Apache's body
-   * decoders raise these when the connection closes or is reset part way through, and no other
-   * part of a download does, so a broken transfer is told apart from a destination that cannot be
-   * written to by the type of the failure rather than by where it was thrown.
+   * Decides whether a failed attempt is worth repeating. Anything that is not known to be permanent
+   * is, because the two ways of being wrong here cost wildly different amounts: repeating a
+   * permanent failure wastes one file's transfers and then fails anyway, whereas declining to
+   * repeat a transient one abandons an export that may represent hours of server-side processing.
+   * Listing what must not be repeated therefore fails in the cheaper direction than listing what
+   * may be, and does not depend on which exception type a given transport or {@link FileStore}
+   * implementation happens to raise for a transfer that was cut short.
    *
    * @param e the failure that ended the attempt
-   * @return true if the transfer was cut short, and so is worth repeating
+   * @return true unless the failure is known to be permanent
    */
-  private static boolean isTruncatedBody(@Nonnull final IOException e) {
-    // ConnectionClosedException is a Content-Length delimited body ending early, and
-    // MalformedChunkCodingException, with its TruncatedChunkException subclass, the chunked
-    // equivalent. A SocketException is the same fault arriving as a reset rather than a close.
-    return e instanceof ConnectionClosedException
-        || e instanceof MalformedChunkCodingException
-        || e instanceof SocketException;
+  private static boolean isWorthRetrying(@Nonnull final IOException e) {
+    // Cancellation must be honoured rather than retried: download() interrupts the outstanding
+    // tasks once any one of them has failed, and a task that swallowed that would keep issuing
+    // requests for an export that has already been abandoned.
+    if (e instanceof InterruptedIOException || e instanceof ClosedByInterruptException) {
+      return false;
+    }
+    // A destination that does not exist or cannot be opened is a misconfigured output location
+    // rather than a fault in transit, so no number of attempts will make it writable. Note that a
+    // destination which fails part way through a write is not in this class: on a file store that
+    // writes over the network that is usually transient, so it is retried.
+    return !(e instanceof AccessDeniedException
+        || e instanceof NoSuchFileException
+        || e instanceof FileNotFoundException);
   }
 
   /**
@@ -154,25 +166,29 @@ public class UrlDownloadTemplate {
       // transfer does not discard an export that may run to thousands of files. The file is
       // rewritten from the start, so a partial write from the previous attempt is replaced.
       //
-      // Only a transfer cut short is retried. A destination that cannot be written to will not be
-      // fixed by fetching the body again, and re-downloading a large file to meet the same full
-      // disk or rejected write wastes the transfer. Failures of the request itself are left to the
-      // HTTP client, which retries them already.
+      // Every failure of an attempt is retried unless it is known to be permanent. A rejected
+      // request is excluded by construction, since HttpError is not an IOException.
       final int maxAttempts = config.getMaxRetries() + 1;
       for (int attempt = 1; ; attempt++) {
         try {
           return attemptDownload();
-        } catch (final IOException e) {
-          if (!isTruncatedBody(e)) {
-            throw e;
+        } catch (final IOException ex) {
+          if (!isWorthRetrying(ex)) {
+            throw ex;
           }
           if (attempt >= maxAttempts) {
             log.error("Failed to download {} after {} attempts", source, attempt);
-            throw e;
+            throw ex;
+          }
+          // The delay cannot be relied on to observe a cancellation, because a zero delay - either
+          // configured or drawn by the jitter - neither sleeps nor throws. Check for it directly so
+          // that a cancelled download stops here rather than starting another attempt.
+          if (Thread.interrupted()) {
+            throw new InterruptedException("Download of " + source + " was cancelled");
           }
           final Duration delay = nextRetryDelay();
-          log.warn("Download of {} failed on attempt {} of {} ({}), retrying in {}", source,
-              attempt, maxAttempts, e.getMessage(), delay);
+          log.debug("Download of {} failed on attempt {} of {} ({}), retrying in {}", source,
+              attempt, maxAttempts, ex.getMessage(), delay);
           TimeUnit.MILLISECONDS.sleep(delay.toMillis());
         }
       }

--- a/src/main/java/au/csiro/fhir/export/ws/BulkExportResponse.java
+++ b/src/main/java/au/csiro/fhir/export/ws/BulkExportResponse.java
@@ -17,9 +17,14 @@
 
 package au.csiro.fhir.export.ws;
 
+import au.csiro.fhir.export.BulkExportException.ProtocolError;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.time.Instant;
 import java.util.Collections;
 import java.util.List;
+import java.util.Set;
+import java.util.regex.Pattern;
 import javax.annotation.Nonnull;
 import lombok.Builder;
 import lombok.Value;
@@ -72,6 +77,62 @@ public class BulkExportResponse implements AsyncResponse {
   @Nonnull
   @Builder.Default
   List<FileItem> error = Collections.emptyList();
+
+  /**
+   * The pattern that a manifest file type must match to be accepted as a FHIR resource type name.
+   * A character class is used rather than the FHIR {@code ResourceType} value set because custom
+   * resource types are legal FHIR and the value set is version specific.
+   */
+  private static final Pattern RESOURCE_TYPE_PATTERN = Pattern.compile("[A-Za-z][A-Za-z0-9]{0,63}");
+
+  /**
+   * The URL schemes that a manifest file url may use.
+   */
+  private static final Set<String> ALLOWED_URL_SCHEMES = Set.of("http", "https");
+
+  /**
+   * Validates the server supplied values that this client consumes.
+   * <p>
+   * The response is deserialised reflectively, which bypasses the constructor and does not honour
+   * {@link Nonnull}, so absent values need to be checked explicitly. Only the values that are
+   * actually used are validated; constraining the rest would reject otherwise usable responses.
+   * <p>
+   * Validating the file type here is what confines download destinations to the output directory:
+   * a type that matches {@link #RESOURCE_TYPE_PATTERN} cannot contain path separators, dot
+   * segments, or a drive letter, and so cannot escape the directory it is resolved against.
+   *
+   * @throws ProtocolError if any of the consumed values is missing or malformed.
+   */
+  public void validate() {
+    if (transactionTime == null) {
+      throw new ProtocolError("Manifest is missing 'transactionTime'");
+    }
+    if (output == null) {
+      throw new ProtocolError("Manifest is missing 'output'");
+    }
+    output.forEach(BulkExportResponse::validateFileItem);
+  }
+
+  private static void validateFileItem(@Nonnull final FileItem fileItem) {
+    final String type = fileItem.getType();
+    if (type == null || !RESOURCE_TYPE_PATTERN.matcher(type).matches()) {
+      throw new ProtocolError("Manifest 'type' is not a valid FHIR resource type name: " + type);
+    }
+    final String url = fileItem.getUrl();
+    if (url == null) {
+      throw new ProtocolError("Manifest 'url' is missing for type: " + type);
+    }
+    final URI uri;
+    try {
+      uri = new URI(url);
+    } catch (final URISyntaxException ex) {
+      throw new ProtocolError("Manifest 'url' is not a valid URI: " + url, ex);
+    }
+    final String scheme = uri.getScheme();
+    if (scheme == null || !ALLOWED_URL_SCHEMES.contains(scheme.toLowerCase())) {
+      throw new ProtocolError("Manifest 'url' has an unsupported scheme: " + url);
+    }
+  }
 
   /**
    * Represents a single file item in the response.

--- a/src/main/java/au/csiro/fhir/export/ws/BulkExportResponse.java
+++ b/src/main/java/au/csiro/fhir/export/ws/BulkExportResponse.java
@@ -23,9 +23,11 @@ import java.net.URISyntaxException;
 import java.time.Instant;
 import java.util.Collections;
 import java.util.List;
+import java.util.Locale;
 import java.util.Set;
 import java.util.regex.Pattern;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import lombok.Builder;
 import lombok.Value;
 
@@ -38,6 +40,18 @@ import lombok.Value;
 @Value
 @Builder
 public class BulkExportResponse implements AsyncResponse {
+
+  /**
+   * The pattern that a manifest file type must match to be accepted as a FHIR resource type name.
+   * A character class is used rather than the FHIR {@code ResourceType} value set because custom
+   * resource types are legal FHIR and the value set is version specific.
+   */
+  private static final Pattern RESOURCE_TYPE_PATTERN = Pattern.compile("[A-Za-z][A-Za-z0-9]{0,63}");
+
+  /**
+   * The URL schemes that a manifest file url may use.
+   */
+  private static final Set<String> ALLOWED_URL_SCHEMES = Set.of("http", "https");
 
   /**
    * Indicates the server's time when the query is run. The 'transactionTime' response value.
@@ -79,18 +93,6 @@ public class BulkExportResponse implements AsyncResponse {
   List<FileItem> error = Collections.emptyList();
 
   /**
-   * The pattern that a manifest file type must match to be accepted as a FHIR resource type name.
-   * A character class is used rather than the FHIR {@code ResourceType} value set because custom
-   * resource types are legal FHIR and the value set is version specific.
-   */
-  private static final Pattern RESOURCE_TYPE_PATTERN = Pattern.compile("[A-Za-z][A-Za-z0-9]{0,63}");
-
-  /**
-   * The URL schemes that a manifest file url may use.
-   */
-  private static final Set<String> ALLOWED_URL_SCHEMES = Set.of("http", "https");
-
-  /**
    * Validates the server supplied values that this client consumes.
    * <p>
    * The response is deserialised reflectively, which bypasses the constructor and does not honour
@@ -113,7 +115,12 @@ public class BulkExportResponse implements AsyncResponse {
     output.forEach(BulkExportResponse::validateFileItem);
   }
 
-  private static void validateFileItem(@Nonnull final FileItem fileItem) {
+  private static void validateFileItem(@Nullable final FileItem fileItem) {
+    // A JSON null in the output array deserialises to a null element, which has to be rejected
+    // here so that a malformed manifest surfaces as a ProtocolError rather than as an NPE.
+    if (fileItem == null) {
+      throw new ProtocolError("Manifest 'output' contains a null entry");
+    }
     final String type = fileItem.getType();
     if (type == null || !RESOURCE_TYPE_PATTERN.matcher(type).matches()) {
       throw new ProtocolError("Manifest 'type' is not a valid FHIR resource type name: " + type);
@@ -129,7 +136,7 @@ public class BulkExportResponse implements AsyncResponse {
       throw new ProtocolError("Manifest 'url' is not a valid URI: " + url, ex);
     }
     final String scheme = uri.getScheme();
-    if (scheme == null || !ALLOWED_URL_SCHEMES.contains(scheme.toLowerCase())) {
+    if (scheme == null || !ALLOWED_URL_SCHEMES.contains(scheme.toLowerCase(Locale.ROOT))) {
       throw new ProtocolError("Manifest 'url' has an unsupported scheme: " + url);
     }
   }

--- a/src/main/java/au/csiro/fhir/export/ws/BulkExportTemplate.java
+++ b/src/main/java/au/csiro/fhir/export/ws/BulkExportTemplate.java
@@ -214,6 +214,9 @@ public class BulkExportTemplate {
 
     @Nonnull
     private CompletedState handleFinalResponse(@Nonnull final BulkExportResponse asyncResponse) {
+      // Validate the manifest here, at the single point where a completed response enters the
+      // interaction, so that everything downstream can rely on its server supplied values.
+      asyncResponse.validate();
       return new CompletedState(asyncResponse, poolingURI);
     }
 

--- a/src/main/java/au/csiro/filestore/FileStore.java
+++ b/src/main/java/au/csiro/filestore/FileStore.java
@@ -76,7 +76,13 @@ public interface FileStore extends Closeable {
     URI toUri();
 
     /**
-     * Write the contents of the input stream to the file.
+     * Write the contents of the input stream to the file, replacing anything already there.
+     * <p>
+     * The file must be written from the start rather than appended to, and must be left holding
+     * exactly the bytes read from the stream. A download that is retried calls this again on the
+     * same handle after an earlier attempt failed part way through, so an implementation that
+     * appended, or that left the tail of a longer earlier write in place, would silently corrupt
+     * the output.
      *
      * @param inputStream the input stream to write.
      * @return the number of bytes written.

--- a/src/main/java/au/csiro/filestore/LocalFileStore.java
+++ b/src/main/java/au/csiro/filestore/LocalFileStore.java
@@ -25,7 +25,6 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.URI;
 import java.nio.file.Files;
-import java.nio.file.LinkOption;
 import java.nio.file.StandardOpenOption;
 import javax.annotation.Nonnull;
 
@@ -67,8 +66,9 @@ class LocalFileStore implements FileStore {
 
     @Override
     public boolean mkdirs() {
-      file.mkdirs();
-      return true;
+      // File.mkdirs() returns false both when creation fails and when the directory is already
+      // there, so the directory has to be checked for as well to report success correctly.
+      return file.mkdirs() || file.isDirectory();
     }
 
     @Nonnull
@@ -91,11 +91,12 @@ class LocalFileStore implements FileStore {
 
     @Override
     public long writeAll(@Nonnull final InputStream is) throws IOException {
-      // Open with CREATE_NEW to refuse to overwrite any pre-existing entry, and NOFOLLOW_LINKS
-      // so that a pre-placed symlink at the destination is not followed to a target outside the
-      // staging directory.
+      // Open with CREATE_NEW so that an existing entry at the destination is never written over,
+      // which covers a symlink pre-placed under the name of a file about to be downloaded.
+      // Symlinks encountered higher up the path are still followed, as pointing an output
+      // directory at other storage through a symlink is a legitimate thing to do.
       try (final OutputStream os = Files.newOutputStream(file.toPath(),
-          StandardOpenOption.CREATE_NEW, LinkOption.NOFOLLOW_LINKS)) {
+          StandardOpenOption.CREATE_NEW)) {
         return IOUtils.copyLarge(is, os);
       }
     }

--- a/src/main/java/au/csiro/filestore/LocalFileStore.java
+++ b/src/main/java/au/csiro/filestore/LocalFileStore.java
@@ -31,6 +31,9 @@ import javax.annotation.Nonnull;
 
 /**
  * An implementation of {@link FileStore} that uses the local filesystem.
+ *
+ * @author Piotr Szul
+ * @author John Grimes
  */
 class LocalFileStore implements FileStore {
 

--- a/src/main/java/au/csiro/filestore/LocalFileStore.java
+++ b/src/main/java/au/csiro/filestore/LocalFileStore.java
@@ -20,11 +20,13 @@ package au.csiro.filestore;
 import lombok.Value;
 import org.apache.commons.io.IOUtils;
 import java.io.File;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.LinkOption;
+import java.nio.file.StandardOpenOption;
 import javax.annotation.Nonnull;
 
 /**
@@ -86,7 +88,11 @@ class LocalFileStore implements FileStore {
 
     @Override
     public long writeAll(@Nonnull final InputStream is) throws IOException {
-      try (final OutputStream os = new FileOutputStream(file)) {
+      // Open with CREATE_NEW to refuse to overwrite any pre-existing entry, and NOFOLLOW_LINKS
+      // so that a pre-placed symlink at the destination is not followed to a target outside the
+      // staging directory.
+      try (final OutputStream os = Files.newOutputStream(file.toPath(),
+          StandardOpenOption.CREATE_NEW, LinkOption.NOFOLLOW_LINKS)) {
         return IOUtils.copyLarge(is, os);
       }
     }

--- a/src/main/java/au/csiro/filestore/hdfs/HdfsFileStoreFactory.java
+++ b/src/main/java/au/csiro/filestore/hdfs/HdfsFileStoreFactory.java
@@ -33,15 +33,27 @@ import org.apache.hadoop.fs.Path;
 /**
  * File store factory based on Apache Hadoop HDFS FileSystem.
  *
- * <p>Filesystems are resolved through the JVM-wide Hadoop filesystem cache and are borrowed rather
- * than owned, so closing a store never closes the filesystem behind it. Releasing cached instances
- * is the host application's business; Hadoop closes what remains at JVM shutdown.
+ * <p>Unless a filesystem is supplied explicitly through {@link #forFileSystem(FileSystem)},
+ * filesystems are resolved with {@link FileSystem#get(URI, Configuration)}, which returns an
+ * instance from the JVM-wide Hadoop filesystem cache that this library shares with the rest of the
+ * host application. Either way the filesystem is borrowed rather than owned, so closing a store
+ * never closes the filesystem behind it. Releasing instances is the host application's business;
+ * Hadoop closes whatever remains in the cache at JVM shutdown, unless the application has turned
+ * that off by setting {@code fs.automatic.close} to false.
  *
  * <p>That obligation becomes a real one in a server that impersonates its users. The cache is keyed
  * on scheme, authority and user, so each distinct user reaching a destination creates an instance
  * that lives until the JVM exits. A server using {@code UserGroupInformation.doAs} should call
  * {@code FileSystem.closeAllForUGI} when it tears a user's session down, or instances will
  * accumulate for as long as the process runs.
+ *
+ * <p>As with {@link FileSystem#get(URI, Configuration)}, the configuration held by this factory is
+ * respected only on a cache miss. Because the key is scheme, authority and user alone, a
+ * destination the host application has already opened resolves to that existing instance and the
+ * configuration is ignored entirely. It takes effect only where the cache has to construct
+ * something, which is why {@link #HdfsFileStoreFactory(Configuration)} should be given the
+ * configuration the application itself uses, rather than relying on
+ * {@link #HdfsFileStoreFactory()}.
  */
 public class HdfsFileStoreFactory implements FileStoreFactory {
 
@@ -51,9 +63,12 @@ public class HdfsFileStoreFactory implements FileStoreFactory {
   /**
    * Creates a factory that resolves filesystems through the Hadoop filesystem cache.
    *
-   * <p>The configuration is only consulted when the cache has to construct a filesystem. The cache
-   * is keyed on scheme, authority and user alone, so if the host application has already opened a
-   * filesystem for the destination, that instance is returned and this configuration is ignored.
+   * <p>Pass the configuration the host application already holds — under Spark, the Hadoop
+   * configuration carrying its {@code spark.hadoop.*} settings — rather than a freshly
+   * constructed one. It is consulted only when the cache has to build a filesystem, but that is
+   * precisely when getting it wrong matters, because what gets built is then cached under the
+   * destination's key and handed to everything that asks for it afterwards, the host application
+   * included.
    *
    * @param configuration the configuration to construct filesystems from, on a cache miss
    */
@@ -63,7 +78,18 @@ public class HdfsFileStoreFactory implements FileStoreFactory {
 
   /**
    * Creates a factory that resolves filesystems through the Hadoop filesystem cache, using a
-   * default configuration when the cache has to construct one.
+   * default {@link Configuration} where the cache has to construct one.
+   *
+   * <p>A default configuration sees only what is on the classpath, in {@code core-site.xml} and its
+   * companions. It sees nothing the host application has configured programmatically, so on a cache
+   * miss for a destination such as {@code s3a://} the filesystem is built without the application's
+   * credentials, endpoint or region, and will usually fail to authenticate. The failure also
+   * outlives this export: the misconfigured instance is left in the JVM-wide cache under the
+   * destination's key, and the host application resolves that same instance from then on.
+   *
+   * <p>Prefer {@link #HdfsFileStoreFactory(Configuration)}. This constructor is only appropriate
+   * where the classpath configuration is genuinely complete, such as a standalone command line
+   * invocation, or where the destination filesystem is known to be open already.
    */
   public HdfsFileStoreFactory() {
     this(new Configuration());
@@ -74,17 +100,21 @@ public class HdfsFileStoreFactory implements FileStoreFactory {
    *
    * <p>Use this when the calling application holds a filesystem that the Hadoop cache will not
    * return for the destination, such as a decorated instance or one opened under a different user.
+   * The supplied filesystem is borrowed on the same terms as a cached one: the stores never close
+   * it, and it remains the caller's to release.
    *
-   * <p>The stores this factory creates ignore the location passed to
-   * {@link #createFileStore(String)} and route every operation through the supplied filesystem. A
-   * location belonging to a different filesystem fails with Hadoop's "Wrong FS" error.
+   * <p>The stores this factory creates ignore the location they are asked for and route every
+   * operation through the supplied filesystem. A location naming a different filesystem fails with
+   * Hadoop's "Wrong FS" error, but only where it names one: a location with no scheme is resolved
+   * against the supplied filesystem without complaint, whatever was intended.
    *
    * <p>Note that the supplied filesystem also fixes the identity that writes are performed as, in
    * place of the one the cache would have selected. A Hadoop filesystem captures its user when it
    * is constructed and keeps it for every later operation, so a server that impersonates its users
    * through {@code UserGroupInformation.doAs} loses that attribution here: every export writes as
    * whichever user opened the supplied instance, whoever requested it. This fails silently, so
-   * prefer {@link #createFileStore(String)} where per-user attribution matters.
+   * prefer a factory built with {@link #HdfsFileStoreFactory(Configuration)} where per-user
+   * attribution matters, and let the cache select the filesystem per user.
    *
    * @param fileSystem the filesystem to write through
    * @return a factory that creates stores over the supplied filesystem

--- a/src/main/java/au/csiro/filestore/hdfs/HdfsFileStoreFactory.java
+++ b/src/main/java/au/csiro/filestore/hdfs/HdfsFileStoreFactory.java
@@ -69,6 +69,31 @@ public class HdfsFileStoreFactory implements FileStoreFactory {
     this(new Configuration());
   }
 
+  /**
+   * Creates a factory that hands out stores over a filesystem supplied by the caller.
+   *
+   * <p>Use this when the calling application holds a filesystem that the Hadoop cache will not
+   * return for the destination, such as a decorated instance or one opened under a different user.
+   *
+   * <p>The stores this factory creates ignore the location passed to
+   * {@link #createFileStore(String)} and route every operation through the supplied filesystem. A
+   * location belonging to a different filesystem fails with Hadoop's "Wrong FS" error.
+   *
+   * <p>Note that the supplied filesystem also fixes the identity that writes are performed as, in
+   * place of the one the cache would have selected. A Hadoop filesystem captures its user when it
+   * is constructed and keeps it for every later operation, so a server that impersonates its users
+   * through {@code UserGroupInformation.doAs} loses that attribution here: every export writes as
+   * whichever user opened the supplied instance, whoever requested it. This fails silently, so
+   * prefer {@link #createFileStore(String)} where per-user attribution matters.
+   *
+   * @param fileSystem the filesystem to write through
+   * @return a factory that creates stores over the supplied filesystem
+   */
+  @Nonnull
+  public static FileStoreFactory forFileSystem(@Nonnull final FileSystem fileSystem) {
+    return location -> new HdfsFileStore(fileSystem);
+  }
+
   @Nonnull
   @Override
   public FileStore createFileStore(@Nonnull final String location) throws IOException {

--- a/src/main/java/au/csiro/filestore/hdfs/HdfsFileStoreFactory.java
+++ b/src/main/java/au/csiro/filestore/hdfs/HdfsFileStoreFactory.java
@@ -32,17 +32,39 @@ import org.apache.hadoop.fs.Path;
 
 /**
  * File store factory based on Apache Hadoop HDFS FileSystem.
+ *
+ * <p>Filesystems are resolved through the JVM-wide Hadoop filesystem cache and are borrowed rather
+ * than owned, so closing a store never closes the filesystem behind it. Releasing cached instances
+ * is the host application's business; Hadoop closes what remains at JVM shutdown.
+ *
+ * <p>That obligation becomes a real one in a server that impersonates its users. The cache is keyed
+ * on scheme, authority and user, so each distinct user reaching a destination creates an instance
+ * that lives until the JVM exits. A server using {@code UserGroupInformation.doAs} should call
+ * {@code FileSystem.closeAllForUGI} when it tears a user's session down, or instances will
+ * accumulate for as long as the process runs.
  */
 public class HdfsFileStoreFactory implements FileStoreFactory {
 
   @Nonnull
   private final Configuration configuration;
 
+  /**
+   * Creates a factory that resolves filesystems through the Hadoop filesystem cache.
+   *
+   * <p>The configuration is only consulted when the cache has to construct a filesystem. The cache
+   * is keyed on scheme, authority and user alone, so if the host application has already opened a
+   * filesystem for the destination, that instance is returned and this configuration is ignored.
+   *
+   * @param configuration the configuration to construct filesystems from, on a cache miss
+   */
   public HdfsFileStoreFactory(@Nonnull final Configuration configuration) {
-    // here we use scala.Option
     this.configuration = configuration;
   }
 
+  /**
+   * Creates a factory that resolves filesystems through the Hadoop filesystem cache, using a
+   * default configuration when the cache has to construct one.
+   */
   public HdfsFileStoreFactory() {
     this(new Configuration());
   }
@@ -59,6 +81,12 @@ public class HdfsFileStoreFactory implements FileStoreFactory {
     @Nonnull
     private final FileSystem fileSystem;
 
+    /**
+     * Creates a store over a filesystem supplied by the caller. The filesystem is borrowed: the
+     * caller retains ownership and remains responsible for closing it.
+     *
+     * @param fileSystem the filesystem to use
+     */
     HdfsFileStore(@Nonnull final FileSystem fileSystem) {
       this.fileSystem = fileSystem;
     }
@@ -70,8 +98,15 @@ public class HdfsFileStoreFactory implements FileStoreFactory {
     }
 
     @Override
-    public void close() throws IOException {
-      fileSystem.close();
+    public void close() {
+      // The filesystem is borrowed, never owned, so this store does not close it. It comes either
+      // from the caller or from the JVM-wide Hadoop cache, which is shared with the host
+      // application; closing a cached instance evicts it and leaves the application holding a
+      // closed filesystem. Cached instances are released by Hadoop's own shutdown hook.
+      //
+      // Files are already durable without this: each write is committed by the try-with-resources
+      // around fileSystem.create in writeAll, which finalises the file through the HDFS write
+      // pipeline and completes the upload on object stores.
     }
 
     @Value

--- a/src/main/java/au/csiro/http/HttpClientConfig.java
+++ b/src/main/java/au/csiro/http/HttpClientConfig.java
@@ -79,7 +79,9 @@ public class HttpClientConfig implements Serializable {
   private boolean retryEnabled = true;
 
   /**
-   * The number of times to retry failed terminology requests.
+   * The number of times to retry a failed request. This is applied by the HTTP client while the
+   * request is in flight, so it does not cover a response body that ends early while being read -
+   * that is retried per file during download instead.
    */
   @NotNull
   @Min(1)

--- a/src/test/java/au/csiro/fhir/example/BulkDataCustomisedExportApp.java
+++ b/src/test/java/au/csiro/fhir/example/BulkDataCustomisedExportApp.java
@@ -2,6 +2,7 @@ package au.csiro.fhir.example;
 
 import au.csiro.fhir.export.BulkExportClient;
 import au.csiro.fhir.export.BulkExportResult;
+import au.csiro.fhir.export.download.DownloadConfig;
 import au.csiro.fhir.export.ws.AsyncConfig;
 import au.csiro.http.HttpClientConfig;
 
@@ -30,7 +31,11 @@ public class BulkDataCustomisedExportApp {
         .retryCount(5)
         .socketTimeout(10_000)
         .build();
-    
+
+    final DownloadConfig downloadConfig = DownloadConfig.builder()
+        .maxRetries(9)
+        .build();
+
     final BulkExportResult result = BulkExportClient.systemBuilder()
         .withFhirEndpointUrl(fhirEndpointUrl)
         .withOutputDir(outputDir)
@@ -38,6 +43,7 @@ public class BulkDataCustomisedExportApp {
         .withTimeout(Duration.ofMinutes(60))
         .withAsyncConfig(asyncConfig)
         .withHttpClientConfig(httpClientConfig)
+        .withDownloadConfig(downloadConfig)
         .build()
         .export();
     

--- a/src/test/java/au/csiro/fhir/example/BulkDataCustomisedExportApp.java
+++ b/src/test/java/au/csiro/fhir/example/BulkDataCustomisedExportApp.java
@@ -34,6 +34,7 @@ public class BulkDataCustomisedExportApp {
 
     final DownloadConfig downloadConfig = DownloadConfig.builder()
         .maxRetries(9)
+        .maxRetryDelay(Duration.ofSeconds(5))
         .build();
 
     final BulkExportResult result = BulkExportClient.systemBuilder()

--- a/src/test/java/au/csiro/fhir/export/BulkExportClientBuilderTest.java
+++ b/src/test/java/au/csiro/fhir/export/BulkExportClientBuilderTest.java
@@ -24,6 +24,7 @@ import au.csiro.fhir.auth.AuthConfig;
 import au.csiro.fhir.export.BulkExportClient.BulkExportClientBuilder;
 import au.csiro.fhir.export.download.DownloadConfig;
 import jakarta.validation.ConstraintViolationException;
+import java.time.Duration;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -51,8 +52,8 @@ public class BulkExportClientBuilderTest {
   }
 
   /**
-   * A retry count is counted down, so it cannot be negative. It is rejected when the client is
-   * built rather than part way through an export.
+   * A delay is slept for and a retry count is counted down, so neither can be negative. They are
+   * rejected when the client is built rather than part way through an export.
    */
   @Test
   void testFailsEarlyWithInvalidDownloadConfiguration() {
@@ -62,6 +63,7 @@ public class BulkExportClientBuilderTest {
         .withOutputDir("output-dir")
         .withDownloadConfig(DownloadConfig.builder()
             .maxRetries(-1)
+            .maxRetryDelay(Duration.ofSeconds(-1))
             .build());
 
     final ConstraintViolationException ex = assertThrows(ConstraintViolationException.class,
@@ -69,7 +71,8 @@ public class BulkExportClientBuilderTest {
 
     assertEquals(
         "Invalid Bulk Export Client Configuration\n"
-            + "downloadConfig.maxRetries: must be greater than or equal to 0",
+            + "downloadConfig.maxRetries: must be greater than or equal to 0\n"
+            + "downloadConfig.maxRetryDelay: must not be negative",
         ex.getMessage());
   }
 

--- a/src/test/java/au/csiro/fhir/export/BulkExportClientBuilderTest.java
+++ b/src/test/java/au/csiro/fhir/export/BulkExportClientBuilderTest.java
@@ -22,6 +22,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import au.csiro.fhir.auth.AuthConfig;
 import au.csiro.fhir.export.BulkExportClient.BulkExportClientBuilder;
+import au.csiro.fhir.export.download.DownloadConfig;
 import jakarta.validation.ConstraintViolationException;
 import org.junit.jupiter.api.Test;
 
@@ -46,6 +47,29 @@ public class BulkExportClientBuilderTest {
             + "authConfig.clientId: must be supplied if auth is enabled\n"
             + "authConfig: either clientSecret or privateKeyJWK must be supplied if auth is enabled\n"
             + "fhirEndpointUrl: must be a valid URL",
+        ex.getMessage());
+  }
+
+  /**
+   * A retry count is counted down, so it cannot be negative. It is rejected when the client is
+   * built rather than part way through an export.
+   */
+  @Test
+  void testFailsEarlyWithInvalidDownloadConfiguration() {
+
+    final BulkExportClientBuilder invalidBuilder = BulkExportClient.builder()
+        .withFhirEndpointUrl("http://foo.bar/fhir")
+        .withOutputDir("output-dir")
+        .withDownloadConfig(DownloadConfig.builder()
+            .maxRetries(-1)
+            .build());
+
+    final ConstraintViolationException ex = assertThrows(ConstraintViolationException.class,
+        invalidBuilder::build);
+
+    assertEquals(
+        "Invalid Bulk Export Client Configuration\n"
+            + "downloadConfig.maxRetries: must be greater than or equal to 0",
         ex.getMessage());
   }
 

--- a/src/test/java/au/csiro/fhir/export/BulkExportClientTest.java
+++ b/src/test/java/au/csiro/fhir/export/BulkExportClientTest.java
@@ -28,6 +28,8 @@ import au.csiro.fhir.export.ws.BulkExportResponse;
 import au.csiro.fhir.export.ws.BulkExportResponse.FileItem;
 import au.csiro.filestore.FileStore.FileHandle;
 import java.net.URI;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.time.Instant;
 import java.util.Collections;
 import java.util.List;
@@ -310,10 +312,16 @@ public class BulkExportClientTest {
         .error(Collections.emptyList())
         .build();
 
-    final List<UrlDownloadEntry> entries = client.getUrlDownloadEntries(
-        response, FileHandle.ofLocal("output-dir"));
+    final FileHandle outputDir = FileHandle.ofLocal("output-dir");
+    final List<UrlDownloadEntry> entries = client.getUrlDownloadEntries(response, outputDir);
 
+    // The destination must be a direct child of the staging directory, with the URL-encoded
+    // sequence preserved as a single filename component (i.e. not decoded into traversal).
     assertEquals(1, entries.size());
-    assertTrue(entries.get(0).getDestination().getLocation().contains("output-dir"));
+    final Path expected = Paths.get("output-dir", "..%2f..%2fsecret.0000.ndjson");
+    final Path actual = Paths.get(entries.get(0).getDestination().getLocation());
+    assertEquals(expected, actual);
+    assertEquals(Paths.get("output-dir").toAbsolutePath().normalize(),
+        actual.toAbsolutePath().normalize().getParent());
   }
 }

--- a/src/test/java/au/csiro/fhir/export/BulkExportClientTest.java
+++ b/src/test/java/au/csiro/fhir/export/BulkExportClientTest.java
@@ -281,6 +281,26 @@ public class BulkExportClientTest {
   }
 
   @Test
+  void testRejectsTypeWithBackslashPathTraversal() {
+    // Backslash separators must be rejected so that traversal sequences are not exploitable on
+    // Windows, where the file system treats backslashes as path separators.
+    final BulkExportResponse response = BulkExportResponse.builder()
+        .transactionTime(Instant.now())
+        .request("fake-request")
+        .output(List.of(
+            new FileItem("..\\..\\secret", "http:/foo.bar/1", 10)
+        ))
+        .deleted(Collections.emptyList())
+        .error(Collections.emptyList())
+        .build();
+
+    final BulkExportException ex = assertThrows(BulkExportException.class,
+        () -> client.getUrlDownloadEntries(response, FileHandle.ofLocal("output-dir")));
+
+    assertTrue(ex.getMessage().contains("invalid path separators"));
+  }
+
+  @Test
   void testRejectsTypeWithAbsolutePath() {
     // A manifest type resolving to an absolute path must be rejected with the absolute-path
     // message specifically (the absolute-path check runs before the separator check).

--- a/src/test/java/au/csiro/fhir/export/BulkExportClientTest.java
+++ b/src/test/java/au/csiro/fhir/export/BulkExportClientTest.java
@@ -18,6 +18,8 @@
 package au.csiro.fhir.export;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import au.csiro.fhir.export.download.UrlDownloadTemplate.UrlDownloadEntry;
 import au.csiro.fhir.export.ws.AssociatedData;
@@ -253,5 +255,65 @@ public class BulkExportClientTest {
         ),
         downloadUrls
     );
+  }
+
+  @Test
+  void testRejectsTypeWithPathTraversal() {
+    // A manifest type containing directory traversal sequences must be rejected.
+    final BulkExportResponse response = BulkExportResponse.builder()
+        .transactionTime(Instant.now())
+        .request("fake-request")
+        .output(List.of(
+            new FileItem("Patient", "http:/foo.bar/1", 10),
+            new FileItem("../../../secret", "http:/foo.bar/2", 10)
+        ))
+        .deleted(Collections.emptyList())
+        .error(Collections.emptyList())
+        .build();
+
+    final BulkExportException ex = assertThrows(BulkExportException.class,
+        () -> client.getUrlDownloadEntries(response, FileHandle.ofLocal("output-dir")));
+
+    assertTrue(ex.getMessage().contains("Manifest file type"));
+  }
+
+  @Test
+  void testRejectsTypeWithAbsolutePath() {
+    // A manifest type resolving to an absolute path must be rejected.
+    final BulkExportResponse response = BulkExportResponse.builder()
+        .transactionTime(Instant.now())
+        .request("fake-request")
+        .output(List.of(
+            new FileItem("/etc/passwd", "http:/foo.bar/1", 10)
+        ))
+        .deleted(Collections.emptyList())
+        .error(Collections.emptyList())
+        .build();
+
+    final BulkExportException ex = assertThrows(BulkExportException.class,
+        () -> client.getUrlDownloadEntries(response, FileHandle.ofLocal("output-dir")));
+
+    assertTrue(ex.getMessage().contains("Manifest file type"));
+  }
+
+  @Test
+  void testConfinesTypeWithUrlEncodedTraversal() {
+    // URL-encoded traversal sequences in the type field are not decoded by the local file
+    // system, so the resulting file remains inside the output directory.
+    final BulkExportResponse response = BulkExportResponse.builder()
+        .transactionTime(Instant.now())
+        .request("fake-request")
+        .output(List.of(
+            new FileItem("..%2f..%2fsecret", "http:/foo.bar/1", 10)
+        ))
+        .deleted(Collections.emptyList())
+        .error(Collections.emptyList())
+        .build();
+
+    final List<UrlDownloadEntry> entries = client.getUrlDownloadEntries(
+        response, FileHandle.ofLocal("output-dir"));
+
+    assertEquals(1, entries.size());
+    assertTrue(entries.get(0).getDestination().getLocation().contains("output-dir"));
   }
 }

--- a/src/test/java/au/csiro/fhir/export/BulkExportClientTest.java
+++ b/src/test/java/au/csiro/fhir/export/BulkExportClientTest.java
@@ -277,12 +277,13 @@ public class BulkExportClientTest {
     final BulkExportException ex = assertThrows(BulkExportException.class,
         () -> client.getUrlDownloadEntries(response, FileHandle.ofLocal("output-dir")));
 
-    assertTrue(ex.getMessage().contains("Manifest file type"));
+    assertTrue(ex.getMessage().contains("invalid path separators"));
   }
 
   @Test
   void testRejectsTypeWithAbsolutePath() {
-    // A manifest type resolving to an absolute path must be rejected.
+    // A manifest type resolving to an absolute path must be rejected with the absolute-path
+    // message specifically (the absolute-path check runs before the separator check).
     final BulkExportResponse response = BulkExportResponse.builder()
         .transactionTime(Instant.now())
         .request("fake-request")
@@ -296,7 +297,8 @@ public class BulkExportClientTest {
     final BulkExportException ex = assertThrows(BulkExportException.class,
         () -> client.getUrlDownloadEntries(response, FileHandle.ofLocal("output-dir")));
 
-    assertTrue(ex.getMessage().contains("Manifest file type"));
+    assertTrue(ex.getMessage().contains("absolute path"),
+        "Expected absolute-path rejection but got: " + ex.getMessage());
   }
 
   @Test

--- a/src/test/java/au/csiro/fhir/export/BulkExportClientTest.java
+++ b/src/test/java/au/csiro/fhir/export/BulkExportClientTest.java
@@ -18,8 +18,6 @@
 package au.csiro.fhir.export;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import au.csiro.fhir.export.download.UrlDownloadTemplate.UrlDownloadEntry;
 import au.csiro.fhir.export.ws.AssociatedData;
@@ -28,19 +26,13 @@ import au.csiro.fhir.export.ws.BulkExportResponse;
 import au.csiro.fhir.export.ws.BulkExportResponse.FileItem;
 import au.csiro.filestore.FileStore.FileHandle;
 import java.net.URI;
-import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.time.Instant;
 import java.util.Collections;
 import java.util.List;
-import javax.annotation.Nonnull;
 import org.junit.jupiter.api.Test;
 
 /**
  * Tests for {@link BulkExportClient}.
- *
- * @author Piotr Szul
- * @author John Grimes
  */
 public class BulkExportClientTest {
 
@@ -261,226 +253,5 @@ public class BulkExportClientTest {
         ),
         downloadUrls
     );
-  }
-
-  @Test
-  void testRejectsTypeWithPathTraversal() {
-    // A manifest type containing directory traversal sequences must be rejected.
-    final BulkExportResponse response = BulkExportResponse.builder()
-        .transactionTime(Instant.now())
-        .request("fake-request")
-        .output(List.of(
-            new FileItem("Patient", "http:/foo.bar/1", 10),
-            new FileItem("../../../secret", "http:/foo.bar/2", 10)
-        ))
-        .deleted(Collections.emptyList())
-        .error(Collections.emptyList())
-        .build();
-
-    final BulkExportException ex = assertThrows(BulkExportException.class,
-        () -> client.getUrlDownloadEntries(response, FileHandle.ofLocal("output-dir")));
-
-    assertTrue(ex.getMessage().contains("invalid path separators"));
-  }
-
-  @Test
-  void testRejectsTypeWithBackslashPathTraversal() {
-    // Backslash separators must be rejected so that traversal sequences are not exploitable on
-    // Windows, where the file system treats backslashes as path separators.
-    final BulkExportResponse response = BulkExportResponse.builder()
-        .transactionTime(Instant.now())
-        .request("fake-request")
-        .output(List.of(
-            new FileItem("..\\..\\secret", "http:/foo.bar/1", 10)
-        ))
-        .deleted(Collections.emptyList())
-        .error(Collections.emptyList())
-        .build();
-
-    final BulkExportException ex = assertThrows(BulkExportException.class,
-        () -> client.getUrlDownloadEntries(response, FileHandle.ofLocal("output-dir")));
-
-    assertTrue(ex.getMessage().contains("invalid path separators"));
-  }
-
-  @Test
-  void testRejectsTypeWithAbsolutePath() {
-    // A manifest type resolving to an absolute path must be rejected with the absolute-path
-    // message specifically (the absolute-path check runs before the separator check).
-    final BulkExportResponse response = BulkExportResponse.builder()
-        .transactionTime(Instant.now())
-        .request("fake-request")
-        .output(List.of(
-            new FileItem("/etc/passwd", "http:/foo.bar/1", 10)
-        ))
-        .deleted(Collections.emptyList())
-        .error(Collections.emptyList())
-        .build();
-
-    final BulkExportException ex = assertThrows(BulkExportException.class,
-        () -> client.getUrlDownloadEntries(response, FileHandle.ofLocal("output-dir")));
-
-    assertTrue(ex.getMessage().contains("absolute path"),
-        "Expected absolute-path rejection but got: " + ex.getMessage());
-  }
-
-  @Test
-  void testConfinesTypeWithUrlEncodedTraversal() {
-    // URL-encoded traversal sequences in the type field are not decoded by the local file
-    // system, so the resulting file remains inside the output directory.
-    final BulkExportResponse response = BulkExportResponse.builder()
-        .transactionTime(Instant.now())
-        .request("fake-request")
-        .output(List.of(
-            new FileItem("..%2f..%2fsecret", "http:/foo.bar/1", 10)
-        ))
-        .deleted(Collections.emptyList())
-        .error(Collections.emptyList())
-        .build();
-
-    final FileHandle outputDir = FileHandle.ofLocal("output-dir");
-    final List<UrlDownloadEntry> entries = client.getUrlDownloadEntries(response, outputDir);
-
-    // The destination must be a direct child of the staging directory, with the URL-encoded
-    // sequence preserved as a single filename component (i.e. not decoded into traversal).
-    assertEquals(1, entries.size());
-    final Path expected = Paths.get("output-dir", "..%2f..%2fsecret.0000.ndjson");
-    final Path actual = Paths.get(entries.get(0).getDestination().getLocation());
-    assertEquals(expected, actual);
-    assertEquals(Paths.get("output-dir").toAbsolutePath().normalize(),
-        actual.toAbsolutePath().normalize().getParent());
-  }
-
-  @Test
-  void testAcceptsRemoteSchemeWhenParentHasQueryString() {
-    // The non-file scheme branch must not be confused by query strings or fragments on the
-    // parent URI: only scheme, authority and path participate in containment.
-    final BulkExportResponse response = BulkExportResponse.builder()
-        .transactionTime(Instant.now())
-        .request("fake-request")
-        .output(List.of(
-            new FileItem("Patient", "http:/foo.bar/1", 10)
-        ))
-        .deleted(Collections.emptyList())
-        .error(Collections.emptyList())
-        .build();
-
-    final FileHandle outputDir = new RemoteFileHandle(
-        URI.create("s3://bucket/output?versionId=abc"));
-
-    final List<UrlDownloadEntry> entries = client.getUrlDownloadEntries(response, outputDir);
-
-    assertEquals(1, entries.size());
-    assertEquals("s3://bucket/output/Patient.0000.ndjson",
-        entries.get(0).getDestination().toUri().toString());
-  }
-
-  @Test
-  void testRejectsRemoteSchemeWithMismatchedAuthority() {
-    // A child whose URI differs in authority must be rejected even when the path appears to
-    // sit beneath the parent path.
-    final BulkExportResponse response = BulkExportResponse.builder()
-        .transactionTime(Instant.now())
-        .request("fake-request")
-        .output(List.of(
-            new FileItem("Patient", "http:/foo.bar/1", 10)
-        ))
-        .deleted(Collections.emptyList())
-        .error(Collections.emptyList())
-        .build();
-
-    // Parent on bucket-a; child URI synthesised on bucket-b. This simulates a misbehaving
-    // FileStore implementation and verifies the authority check catches it.
-    final FileHandle outputDir = new RemoteFileHandle(URI.create("s3://bucket-a/output")) {
-      @Nonnull
-      @Override
-      public FileHandle child(@Nonnull final String childName) {
-        return new RemoteFileHandle(URI.create("s3://bucket-b/output/" + childName));
-      }
-    };
-
-    final BulkExportException ex = assertThrows(BulkExportException.class,
-        () -> client.getUrlDownloadEntries(response, outputDir));
-    assertTrue(ex.getMessage().contains("outside the output directory"));
-  }
-
-  @Test
-  void testRejectsRemoteSchemeWithTraversalInChildPath() {
-    // A child URI whose normalised path escapes the parent's path must be rejected.
-    final BulkExportResponse response = BulkExportResponse.builder()
-        .transactionTime(Instant.now())
-        .request("fake-request")
-        .output(List.of(
-            new FileItem("Patient", "http:/foo.bar/1", 10)
-        ))
-        .deleted(Collections.emptyList())
-        .error(Collections.emptyList())
-        .build();
-
-    final FileHandle outputDir = new RemoteFileHandle(URI.create("s3://bucket/output")) {
-      @Nonnull
-      @Override
-      public FileHandle child(@Nonnull final String childName) {
-        return new RemoteFileHandle(URI.create("s3://bucket/output/../../secret/" + childName));
-      }
-    };
-
-    final BulkExportException ex = assertThrows(BulkExportException.class,
-        () -> client.getUrlDownloadEntries(response, outputDir));
-    assertTrue(ex.getMessage().contains("outside the output directory"));
-  }
-
-  /**
-   * Minimal FileHandle stub for exercising the non-file scheme branch of the descendant check.
-   * Only toUri, getLocation and child are used by getUrlDownloadEntries.
-   */
-  private static class RemoteFileHandle implements FileHandle {
-
-    @Nonnull
-    private final URI uri;
-
-    RemoteFileHandle(@Nonnull final URI uri) {
-      this.uri = uri;
-    }
-
-    @Override
-    public boolean exists() {
-      return false;
-    }
-
-    @Override
-    public boolean mkdirs() {
-      return true;
-    }
-
-    @Nonnull
-    @Override
-    public FileHandle child(@Nonnull final String childName) {
-      // Default behaviour: append the child name to the path component, preserving the
-      // authority and dropping any query/fragment so the child is a clean path beneath the
-      // parent.
-      final String basePath = uri.getPath() == null ? "" : uri.getPath();
-      final String separator = basePath.endsWith("/") ? "" : "/";
-      final URI childUri = URI.create(uri.getScheme() + "://" + uri.getAuthority()
-          + basePath + separator + childName);
-      return new RemoteFileHandle(childUri);
-    }
-
-    @Nonnull
-    @Override
-    public String getLocation() {
-      return uri.toString();
-    }
-
-    @Nonnull
-    @Override
-    public URI toUri() {
-      return uri;
-    }
-
-    @Override
-    public long writeAll(@Nonnull final java.io.InputStream inputStream) {
-      throw new UnsupportedOperationException();
-    }
   }
 }

--- a/src/test/java/au/csiro/fhir/export/BulkExportClientTest.java
+++ b/src/test/java/au/csiro/fhir/export/BulkExportClientTest.java
@@ -33,6 +33,7 @@ import java.nio.file.Paths;
 import java.time.Instant;
 import java.util.Collections;
 import java.util.List;
+import javax.annotation.Nonnull;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -323,5 +324,138 @@ public class BulkExportClientTest {
     assertEquals(expected, actual);
     assertEquals(Paths.get("output-dir").toAbsolutePath().normalize(),
         actual.toAbsolutePath().normalize().getParent());
+  }
+
+  @Test
+  void testAcceptsRemoteSchemeWhenParentHasQueryString() {
+    // The non-file scheme branch must not be confused by query strings or fragments on the
+    // parent URI: only scheme, authority and path participate in containment.
+    final BulkExportResponse response = BulkExportResponse.builder()
+        .transactionTime(Instant.now())
+        .request("fake-request")
+        .output(List.of(
+            new FileItem("Patient", "http:/foo.bar/1", 10)
+        ))
+        .deleted(Collections.emptyList())
+        .error(Collections.emptyList())
+        .build();
+
+    final FileHandle outputDir = new RemoteFileHandle(
+        URI.create("s3://bucket/output?versionId=abc"));
+
+    final List<UrlDownloadEntry> entries = client.getUrlDownloadEntries(response, outputDir);
+
+    assertEquals(1, entries.size());
+    assertEquals("s3://bucket/output/Patient.0000.ndjson",
+        entries.get(0).getDestination().toUri().toString());
+  }
+
+  @Test
+  void testRejectsRemoteSchemeWithMismatchedAuthority() {
+    // A child whose URI differs in authority must be rejected even when the path appears to
+    // sit beneath the parent path.
+    final BulkExportResponse response = BulkExportResponse.builder()
+        .transactionTime(Instant.now())
+        .request("fake-request")
+        .output(List.of(
+            new FileItem("Patient", "http:/foo.bar/1", 10)
+        ))
+        .deleted(Collections.emptyList())
+        .error(Collections.emptyList())
+        .build();
+
+    // Parent on bucket-a; child URI synthesised on bucket-b. This simulates a misbehaving
+    // FileStore implementation and verifies the authority check catches it.
+    final FileHandle outputDir = new RemoteFileHandle(URI.create("s3://bucket-a/output")) {
+      @Nonnull
+      @Override
+      public FileHandle child(@Nonnull final String childName) {
+        return new RemoteFileHandle(URI.create("s3://bucket-b/output/" + childName));
+      }
+    };
+
+    final BulkExportException ex = assertThrows(BulkExportException.class,
+        () -> client.getUrlDownloadEntries(response, outputDir));
+    assertTrue(ex.getMessage().contains("outside the output directory"));
+  }
+
+  @Test
+  void testRejectsRemoteSchemeWithTraversalInChildPath() {
+    // A child URI whose normalised path escapes the parent's path must be rejected.
+    final BulkExportResponse response = BulkExportResponse.builder()
+        .transactionTime(Instant.now())
+        .request("fake-request")
+        .output(List.of(
+            new FileItem("Patient", "http:/foo.bar/1", 10)
+        ))
+        .deleted(Collections.emptyList())
+        .error(Collections.emptyList())
+        .build();
+
+    final FileHandle outputDir = new RemoteFileHandle(URI.create("s3://bucket/output")) {
+      @Nonnull
+      @Override
+      public FileHandle child(@Nonnull final String childName) {
+        return new RemoteFileHandle(URI.create("s3://bucket/output/../../secret/" + childName));
+      }
+    };
+
+    final BulkExportException ex = assertThrows(BulkExportException.class,
+        () -> client.getUrlDownloadEntries(response, outputDir));
+    assertTrue(ex.getMessage().contains("outside the output directory"));
+  }
+
+  /**
+   * Minimal FileHandle stub for exercising the non-file scheme branch of the descendant check.
+   * Only toUri, getLocation and child are used by getUrlDownloadEntries.
+   */
+  private static class RemoteFileHandle implements FileHandle {
+
+    @Nonnull
+    private final URI uri;
+
+    RemoteFileHandle(@Nonnull final URI uri) {
+      this.uri = uri;
+    }
+
+    @Override
+    public boolean exists() {
+      return false;
+    }
+
+    @Override
+    public boolean mkdirs() {
+      return true;
+    }
+
+    @Nonnull
+    @Override
+    public FileHandle child(@Nonnull final String childName) {
+      // Default behaviour: append the child name to the path component, preserving the
+      // authority and dropping any query/fragment so the child is a clean path beneath the
+      // parent.
+      final String basePath = uri.getPath() == null ? "" : uri.getPath();
+      final String separator = basePath.endsWith("/") ? "" : "/";
+      final URI childUri = URI.create(uri.getScheme() + "://" + uri.getAuthority()
+          + basePath + separator + childName);
+      return new RemoteFileHandle(childUri);
+    }
+
+    @Nonnull
+    @Override
+    public String getLocation() {
+      return uri.toString();
+    }
+
+    @Nonnull
+    @Override
+    public URI toUri() {
+      return uri;
+    }
+
+    @Override
+    public long writeAll(@Nonnull final java.io.InputStream inputStream) {
+      throw new UnsupportedOperationException();
+    }
   }
 }

--- a/src/test/java/au/csiro/fhir/export/BulkExportClientTest.java
+++ b/src/test/java/au/csiro/fhir/export/BulkExportClientTest.java
@@ -38,6 +38,9 @@ import org.junit.jupiter.api.Test;
 
 /**
  * Tests for {@link BulkExportClient}.
+ *
+ * @author Piotr Szul
+ * @author John Grimes
  */
 public class BulkExportClientTest {
 

--- a/src/test/java/au/csiro/fhir/export/BulkExportClientWiremockTest.java
+++ b/src/test/java/au/csiro/fhir/export/BulkExportClientWiremockTest.java
@@ -50,6 +50,7 @@ import com.google.common.base.Charsets;
 import java.io.File;
 import java.io.IOException;
 import java.net.URI;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Duration;
 import java.time.Instant;
@@ -885,6 +886,14 @@ class BulkExportClientWiremockTest {
     );
     assertTrue(ex.getMessage().contains("Manifest file type"));
     assertNotMarkedSuccess(exportDir);
+
+    // The manifest type "../../secret" with the chunk and extension suffix would resolve to a
+    // sibling of the target directory if the traversal had succeeded. Assert that no such file
+    // appears, which directly disproves the published PoC's exfiltration claim.
+    final Path escapeTarget = exportDir.toPath().toAbsolutePath()
+        .resolve("../../secret.0000.ndjson").normalize();
+    assertFalse(Files.exists(escapeTarget),
+        "File written outside staging directory: " + escapeTarget);
 
     // check that cleanup was called
     verify(1, deleteRequestedFor(urlPathEqualTo("/pool")));

--- a/src/test/java/au/csiro/fhir/export/BulkExportClientWiremockTest.java
+++ b/src/test/java/au/csiro/fhir/export/BulkExportClientWiremockTest.java
@@ -63,6 +63,12 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import wiremock.net.minidev.json.JSONArray;
 
+/**
+ * WireMock-based tests for {@link BulkExportClient}.
+ *
+ * @author Piotr Szul
+ * @author John Grimes
+ */
 @WireMockTest
 class BulkExportClientWiremockTest {
 

--- a/src/test/java/au/csiro/fhir/export/BulkExportClientWiremockTest.java
+++ b/src/test/java/au/csiro/fhir/export/BulkExportClientWiremockTest.java
@@ -832,6 +832,65 @@ class BulkExportClientWiremockTest {
   }
 
   @Test
+  void testExportFailsOnPoisonedManifestType(@Nonnull final WireMockRuntimeInfo wmRuntimeInfo) {
+
+    stubFor(get(anyUrl()).willReturn(aResponse().withStatus(500)));
+
+    stubFor(get(urlPathEqualTo("/$export"))
+        .inScenario("bulk-export")
+        .whenScenarioStateIs(STARTED)
+        .willReturn(
+            aResponse().withStatus(202)
+                .withHeader("content-location", wmRuntimeInfo.getHttpBaseUrl() + "/pool"))
+        .willSetStateTo("done")
+    );
+
+    stubFor(delete(urlPathEqualTo("/pool"))
+        .willReturn(aResponse().withStatus(202))
+    );
+
+    stubFor(get(urlPathEqualTo("/pool"))
+        .inScenario("bulk-export")
+        .whenScenarioStateIs("done")
+        .willReturn(aResponse().withStatus(200).withBody(
+            new JSONObject()
+                .put("transactionTime", "1970-02-27T12:39:04.343Z")
+                .put("request", "http://localhost:8080/$export")
+                .put("requiresAccessToken", false)
+                .put("output", new JSONArray()
+                    .appendElement(new JSONObject()
+                        .put("type", "../../secret")
+                        .put("url", wmRuntimeInfo.getHttpBaseUrl() + "/file/00")
+                        .put("count", 2)
+                    )
+                )
+                .toString()
+        ))
+    );
+
+    stubFor(get(urlPathEqualTo("/file/00"))
+        .willReturn(aResponse()
+            .withStatus(200)
+            .withBody(RESOURCE_00))
+    );
+
+    final File exportDir = getRandomExportLocation();
+
+    final BulkExportException ex = Assertions.assertThrows(BulkExportException.class, () ->
+        BulkExportClient.builder()
+            .withFhirEndpointUrl(wmRuntimeInfo.getHttpBaseUrl())
+            .withOutputDir(exportDir.getPath())
+            .build()
+            .export()
+    );
+    assertTrue(ex.getMessage().contains("Manifest file type"));
+    assertNotMarkedSuccess(exportDir);
+
+    // check that cleanup was called
+    verify(1, deleteRequestedFor(urlPathEqualTo("/pool")));
+  }
+
+  @Test
   void testExportWorksWithSMARTSymmetricAuthenticationForKickOffAndDownloadRefreshingExpiredTokens(
       @Nonnull final WireMockRuntimeInfo wmRuntimeInfo) throws IOException {
 

--- a/src/test/java/au/csiro/fhir/export/BulkExportClientWiremockTest.java
+++ b/src/test/java/au/csiro/fhir/export/BulkExportClientWiremockTest.java
@@ -882,7 +882,12 @@ class BulkExportClientWiremockTest {
             .withBody(RESOURCE_00))
     );
 
-    final File exportDir = getRandomExportLocation();
+    // The output directory is nested two levels inside this test's own scratch directory, so that
+    // the two levels of traversal in the manifest type land inside it rather than somewhere shared.
+    // The parent of the escape target exists (the client creates the output directory before
+    // fetching the manifest), so the traversal would still succeed if it were not rejected.
+    final File scratchDir = getRandomExportLocation();
+    final File exportDir = new File(scratchDir, "nested/output");
 
     final ProtocolError ex = Assertions.assertThrows(ProtocolError.class, () ->
         BulkExportClient.builder()
@@ -896,10 +901,12 @@ class BulkExportClientWiremockTest {
     assertNotMarkedSuccess(exportDir);
 
     // The manifest type "../../secret" with the chunk and extension suffix would resolve to a
-    // sibling of the output directory if the traversal had succeeded, so assert that no such file
-    // appears.
+    // sibling of the output directory's parent if the traversal had succeeded, so assert that no
+    // such file appears.
     final Path escapeTarget = exportDir.toPath().toAbsolutePath()
         .resolve("../../secret.0000.ndjson").normalize();
+    assertEquals(scratchDir.toPath().toAbsolutePath().resolve("secret.0000.ndjson"), escapeTarget,
+        "The escape target must stay inside this test's scratch directory");
     assertFalse(Files.exists(escapeTarget),
         "File written outside output directory: " + escapeTarget);
 

--- a/src/test/java/au/csiro/fhir/export/BulkExportClientWiremockTest.java
+++ b/src/test/java/au/csiro/fhir/export/BulkExportClientWiremockTest.java
@@ -41,6 +41,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import au.csiro.fhir.auth.AuthConfig;
 import au.csiro.fhir.export.BulkExportException.HttpError;
+import au.csiro.fhir.export.BulkExportException.ProtocolError;
 import au.csiro.fhir.model.Reference;
 import au.csiro.fhir.export.ws.AssociatedData;
 import au.csiro.fhir.export.ws.BulkExportRequest;
@@ -883,23 +884,27 @@ class BulkExportClientWiremockTest {
 
     final File exportDir = getRandomExportLocation();
 
-    final BulkExportException ex = Assertions.assertThrows(BulkExportException.class, () ->
+    final ProtocolError ex = Assertions.assertThrows(ProtocolError.class, () ->
         BulkExportClient.builder()
             .withFhirEndpointUrl(wmRuntimeInfo.getHttpBaseUrl())
             .withOutputDir(exportDir.getPath())
             .build()
             .export()
     );
-    assertTrue(ex.getMessage().contains("Manifest file type"));
+    assertEquals("Manifest 'type' is not a valid FHIR resource type name: ../../secret",
+        ex.getMessage());
     assertNotMarkedSuccess(exportDir);
 
     // The manifest type "../../secret" with the chunk and extension suffix would resolve to a
-    // sibling of the target directory if the traversal had succeeded. Assert that no such file
-    // appears, which directly disproves the published PoC's exfiltration claim.
+    // sibling of the output directory if the traversal had succeeded, so assert that no such file
+    // appears.
     final Path escapeTarget = exportDir.toPath().toAbsolutePath()
         .resolve("../../secret.0000.ndjson").normalize();
     assertFalse(Files.exists(escapeTarget),
-        "File written outside staging directory: " + escapeTarget);
+        "File written outside output directory: " + escapeTarget);
+
+    // No download should have been attempted for the rejected entry.
+    verify(0, getRequestedFor(urlPathEqualTo("/file/00")));
 
     // check that cleanup was called
     verify(1, deleteRequestedFor(urlPathEqualTo("/pool")));

--- a/src/test/java/au/csiro/fhir/export/download/UrlDownloadTemplateTest.java
+++ b/src/test/java/au/csiro/fhir/export/download/UrlDownloadTemplateTest.java
@@ -180,6 +180,15 @@ class UrlDownloadTemplateTest {
   }
 
   /**
+   * The two-argument constructor predates the configuration and is public API of a released
+   * version, so it keeps working and supplies the defaults rather than being taken away.
+   */
+  @Test
+  void testDefaultsTheConfigurationWhenNotGiven() {
+    assertEquals(DEFAULTS, new UrlDownloadTemplate(httpClient, executorService).config);
+  }
+
+  /**
    * A body that yields some bytes and then fails, as one cut short mid-transfer does.
    *
    * @param bytesBeforeFailure the number of bytes served before the failure

--- a/src/test/java/au/csiro/fhir/export/download/UrlDownloadTemplateTest.java
+++ b/src/test/java/au/csiro/fhir/export/download/UrlDownloadTemplateTest.java
@@ -18,6 +18,7 @@
 package au.csiro.fhir.export.download;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.eq;
@@ -36,12 +37,14 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.SocketException;
 import java.net.URI;
+import java.nio.file.AccessDeniedException;
 import java.time.Duration;
 import java.util.List;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import javax.annotation.Nonnull;
+import javax.net.ssl.SSLException;
 import org.apache.commons.io.IOUtils;
 import org.apache.http.ConnectionClosedException;
 import org.apache.http.HttpResponse;
@@ -235,6 +238,25 @@ class UrlDownloadTemplateTest {
   }
 
   /**
+   * A body cut short at the same moment the download is cancelled, which is the ordering that
+   * matters: the task is interrupted while it is in the middle of a transfer that then fails.
+   *
+   * @return the body
+   */
+  @Nonnull
+  private static InputStream truncatedBodyOnCancelledDownload() {
+    return new InputStream() {
+
+      @Override
+      public int read() throws IOException {
+        Thread.currentThread().interrupt();
+        throw new ConnectionClosedException(
+            "Premature end of Content-Length delimited message body");
+      }
+    };
+  }
+
+  /**
    * Copies the body through to a sink, so that a read failure surfaces from where it would in
    * production: part way through the copy that {@code writeAll} performs.
    */
@@ -398,49 +420,127 @@ class UrlDownloadTemplateTest {
   }
 
   /**
-   * Retrying is confined to a transfer that was cut short, which is recognised by the type of the
-   * failure. Any other way of reading the body failing is not known to be transient, so repeating
-   * the transfer for it is not assumed to help.
+   * A transfer cut short does not arrive as one recognisable type. Over TLS it surfaces as an
+   * {@link SSLException}, which the HTTP client also declines to retry, so nothing would retry the
+   * originating failure of this issue on the HTTPS endpoints every real server uses.
    */
   @Test
-  void testDownloadTaskDoesNotRetryOtherReadFailures() throws Exception {
+  void testDownloadTaskRetriesAfterTlsTruncation() throws Exception {
     when(httpClient.execute(Mockito.any())).thenReturn(httpResponse);
     when(httpResponse.getStatusLine()).thenReturn(
         new BasicStatusLine(new ProtocolVersion("http", 1, 1), 200, "OK"));
-    when(httpResponse.getEntity()).thenReturn(new InputStreamEntity(
-        bodyFailingAfter(1, new IOException("Malformed response")), 3));
+    when(httpResponse.getEntity())
+        .thenReturn(new InputStreamEntity(
+            bodyFailingAfter(1, new SSLException("Unexpected end of stream")), 3))
+        .thenReturn(new InputStreamEntity(new ByteArrayInputStream(new byte[]{1, 2, 3}), 3));
     writeAllConsumesTheBody();
 
     final UrlDownloadTemplate template = new UrlDownloadTemplate(httpClient, executorService,
         NO_DELAY);
-    final IOException ex = assertThrows(IOException.class,
-        () -> template.new UriDownloadTask(URI.create("http://foo.bar/file1"), fileHandle).call());
+    final long written = template.new UriDownloadTask(URI.create("http://foo.bar/file1"),
+        fileHandle).call();
 
-    assertEquals("Malformed response", ex.getMessage());
-    verify(httpClient, Mockito.times(1)).execute(Mockito.any());
+    assertEquals(3L, written);
+    verify(httpClient, Mockito.times(2)).execute(Mockito.any());
   }
 
   /**
-   * A destination that cannot be written to is not a broken transfer. Fetching the body again
-   * cannot fix a full disk or a rejected write, so the transfer is not repeated for it.
+   * Which type a cut-short transfer arrives as depends on the transport and on how the body was
+   * encoded, so a read failure is repeated whether or not it is one of the recognised shapes. The
+   * cost of being wrong is one file's transfers; the cost of not retrying a transient fault is the
+   * whole export.
    */
   @Test
-  void testDownloadTaskDoesNotRetryDestinationFailure() throws Exception {
+  void testDownloadTaskRetriesUnrecognisedReadFailures() throws Exception {
+    when(httpClient.execute(Mockito.any())).thenReturn(httpResponse);
+    when(httpResponse.getStatusLine()).thenReturn(
+        new BasicStatusLine(new ProtocolVersion("http", 1, 1), 200, "OK"));
+    when(httpResponse.getEntity())
+        .thenReturn(new InputStreamEntity(
+            bodyFailingAfter(1, new IOException("Malformed response")), 3))
+        .thenReturn(new InputStreamEntity(new ByteArrayInputStream(new byte[]{1, 2, 3}), 3));
+    writeAllConsumesTheBody();
+
+    final UrlDownloadTemplate template = new UrlDownloadTemplate(httpClient, executorService,
+        NO_DELAY);
+    final long written = template.new UriDownloadTask(URI.create("http://foo.bar/file1"),
+        fileHandle).call();
+
+    assertEquals(3L, written);
+    verify(httpClient, Mockito.times(2)).execute(Mockito.any());
+  }
+
+  /**
+   * A destination that fails part way through a write is not assumed to be permanent. On a file
+   * store that writes over the network, which {@code HdfsFileHandle} does, that is the common
+   * transient fault, and it cannot be told apart from a read failure by type in any case.
+   */
+  @Test
+  void testDownloadTaskRetriesDestinationFailureMidWrite() throws Exception {
+    when(httpClient.execute(Mockito.any())).thenReturn(httpResponse);
+    when(httpResponse.getStatusLine()).thenReturn(
+        new BasicStatusLine(new ProtocolVersion("http", 1, 1), 200, "OK"));
+    when(httpResponse.getEntity()).thenAnswer(
+        invocation -> new InputStreamEntity(new ByteArrayInputStream(new byte[]{1, 2, 3}), 3));
+    when(fileHandle.writeAll(Mockito.any()))
+        .thenThrow(new IOException("Connection reset by peer"))
+        .thenReturn(3L);
+
+    final UrlDownloadTemplate template = new UrlDownloadTemplate(httpClient, executorService,
+        NO_DELAY);
+    final long written = template.new UriDownloadTask(URI.create("http://foo.bar/file1"),
+        fileHandle).call();
+
+    assertEquals(3L, written);
+    verify(httpClient, Mockito.times(2)).execute(Mockito.any());
+  }
+
+  /**
+   * A destination that cannot be opened at all is a misconfigured output location rather than a
+   * fault in transit, so no number of attempts will make it writable and the transfer is not
+   * repeated for it.
+   */
+  @Test
+  void testDownloadTaskDoesNotRetryUnwritableDestination() throws Exception {
     when(httpClient.execute(Mockito.any())).thenReturn(httpResponse);
     when(httpResponse.getStatusLine()).thenReturn(
         new BasicStatusLine(new ProtocolVersion("http", 1, 1), 200, "OK"));
     when(httpResponse.getEntity()).thenReturn(
         new InputStreamEntity(new ByteArrayInputStream(new byte[]{1, 2, 3}), 3));
     when(fileHandle.writeAll(Mockito.any()))
-        .thenThrow(new IOException("No space left on device"));
+        .thenThrow(new AccessDeniedException("output-dir/file1"));
 
     final UrlDownloadTemplate template = new UrlDownloadTemplate(httpClient, executorService,
         NO_DELAY);
-    final IOException ex = assertThrows(IOException.class,
+    assertThrows(AccessDeniedException.class,
         () -> template.new UriDownloadTask(URI.create("http://foo.bar/file1"), fileHandle).call());
 
-    assertEquals("No space left on device", ex.getMessage());
     verify(httpClient, Mockito.times(1)).execute(Mockito.any());
+  }
+
+  /**
+   * Retrying must not outlive the export it belongs to. Once any one download has failed
+   * {@code download()} interrupts the rest, and a task that treated its own cancellation as a
+   * transient fault would keep issuing requests for work that has already been abandoned. A zero
+   * delay neither sleeps nor throws, so the interrupt has to be observed independently of it.
+   */
+  @Test
+  void testDownloadTaskStopsWhenCancelled() throws Exception {
+    when(httpClient.execute(Mockito.any())).thenReturn(httpResponse);
+    when(httpResponse.getStatusLine()).thenReturn(
+        new BasicStatusLine(new ProtocolVersion("http", 1, 1), 200, "OK"));
+    when(httpResponse.getEntity()).thenAnswer(
+        invocation -> new InputStreamEntity(truncatedBodyOnCancelledDownload(), 3));
+    writeAllConsumesTheBody();
+
+    final UrlDownloadTemplate template = new UrlDownloadTemplate(httpClient, executorService,
+        NO_DELAY);
+    assertThrows(InterruptedException.class,
+        () -> template.new UriDownloadTask(URI.create("http://foo.bar/file1"), fileHandle).call());
+
+    verify(httpClient, Mockito.times(1)).execute(Mockito.any());
+    assertFalse(Thread.currentThread().isInterrupted(),
+        "The interrupt should have been consumed by the InterruptedException");
   }
 
   /**

--- a/src/test/java/au/csiro/fhir/export/download/UrlDownloadTemplateTest.java
+++ b/src/test/java/au/csiro/fhir/export/download/UrlDownloadTemplateTest.java
@@ -33,12 +33,17 @@ import au.csiro.utils.TimeoutUtils;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.SocketException;
 import java.net.URI;
 import java.time.Duration;
 import java.util.List;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
+import javax.annotation.Nonnull;
+import org.apache.commons.io.IOUtils;
+import org.apache.http.ConnectionClosedException;
 import org.apache.http.HttpResponse;
 import org.apache.http.ProtocolVersion;
 import org.apache.http.client.HttpClient;
@@ -68,9 +73,18 @@ class UrlDownloadTemplateTest {
   @Mock
   FileHandle fileHandle;
 
+  @Captor
+  ArgumentCaptor<HttpUriRequest> httpRequestCaptor;
+
+  /**
+   * What a caller who does not customise the download gets.
+   */
+  private static final DownloadConfig DEFAULTS = DownloadConfig.builder().build();
+
   @Test
   void testDownloadsAllUrlsSuccessfully() {
-    final UrlDownloadTemplate template = new UrlDownloadTemplate(httpClient, executorService);
+    final UrlDownloadTemplate template = new UrlDownloadTemplate(httpClient, executorService,
+        DEFAULTS);
     when(executorService.submit(eq(template.new UriDownloadTask(URI.create("http://foo.bar/file1"),
         FileHandle.ofLocal("file1"))))).thenReturn(CompletableFuture.completedFuture(3L));
     when(executorService.submit(eq(template.new UriDownloadTask(URI.create("http://foo.bar/file2"),
@@ -86,7 +100,8 @@ class UrlDownloadTemplateTest {
   @SuppressWarnings("unchecked")
   @Test
   void testThrowsTimeoutExceptionWhenTimeout() {
-    final UrlDownloadTemplate template = new UrlDownloadTemplate(httpClient, executorService);
+    final UrlDownloadTemplate template = new UrlDownloadTemplate(httpClient, executorService,
+        DEFAULTS);
     when(executorService.submit(Mockito.any(Callable.class))).thenReturn(new CompletableFuture<>());
 
     final Timeout ex = assertThrows(Timeout.class,
@@ -103,7 +118,8 @@ class UrlDownloadTemplateTest {
     final IOException downloadEx = new IOException("IO Error");
     final CompletableFuture<Long> runningFuture = new CompletableFuture<>();
 
-    final UrlDownloadTemplate template = new UrlDownloadTemplate(httpClient, executorService);
+    final UrlDownloadTemplate template = new UrlDownloadTemplate(httpClient, executorService,
+        DEFAULTS);
     when(executorService.submit(eq(template.new UriDownloadTask(URI.create("http://foo.bar/file1"),
         FileHandle.ofLocal("file1"))))).thenReturn(
         CompletableFuture.failedFuture(downloadEx));
@@ -121,10 +137,6 @@ class UrlDownloadTemplateTest {
     assertTrue(runningFuture.isCancelled());
   }
 
-
-  @Captor
-  ArgumentCaptor<HttpUriRequest> httpRequestCaptor;
-
   @Test
   void testDownloadTaskGetsTheFileOnSuccess() throws Exception {
     final InputStream responseStream = new ByteArrayInputStream(new byte[]{1, 2, 3});
@@ -133,7 +145,8 @@ class UrlDownloadTemplateTest {
         new BasicStatusLine(new ProtocolVersion("http", 1, 1), 200, "OK"));
     when(httpResponse.getEntity()).thenReturn(new InputStreamEntity(responseStream, 3));
     when(fileHandle.writeAll(Mockito.eq(responseStream))).thenReturn(7L);
-    final UrlDownloadTemplate template = new UrlDownloadTemplate(httpClient, executorService);
+    final UrlDownloadTemplate template = new UrlDownloadTemplate(httpClient, executorService,
+        DEFAULTS);
     final UrlDownloadTemplate.UriDownloadTask task = template.new UriDownloadTask(
         URI.create("http://foo.bar/file1"),
         fileHandle);
@@ -148,10 +161,262 @@ class UrlDownloadTemplateTest {
     when(httpClient.execute(Mockito.any())).thenReturn(httpResponse);
     when(httpResponse.getStatusLine()).thenReturn(
         new BasicStatusLine(new ProtocolVersion("http", 1, 1), 500, "Internal Server Error"));
-    final UrlDownloadTemplate template = new UrlDownloadTemplate(httpClient, executorService);
+    final UrlDownloadTemplate template = new UrlDownloadTemplate(httpClient, executorService,
+        DEFAULTS);
     final HttpError ex = assertThrows(HttpError.class, () -> template.new UriDownloadTask(
         URI.create("http://foo.bar/file1"),
         fileHandle).call());
     assertEquals("Failed to download: http://foo.bar/file1: [statusCode: 500]", ex.getMessage());
+  }
+
+  /**
+   * A body that yields some bytes and then fails, as one cut short mid-transfer does.
+   *
+   * @param bytesBeforeFailure the number of bytes served before the failure
+   * @param failure the failure to raise once those bytes have been served
+   * @return the body
+   */
+  @Nonnull
+  private static InputStream bodyFailingAfter(final int bytesBeforeFailure,
+      @Nonnull final IOException failure) {
+    return new InputStream() {
+
+      private int served;
+
+      @Override
+      public int read() throws IOException {
+        if (served++ < bytesBeforeFailure) {
+          return 1;
+        }
+        throw failure;
+      }
+    };
+  }
+
+  /**
+   * A body cut short the way a Content-Length delimited one is, which is the failure reported in
+   * the originating issue.
+   *
+   * @param bytesBeforeFailure the number of bytes served before the truncation
+   * @return the body
+   */
+  @Nonnull
+  private static InputStream truncatedBody(final int bytesBeforeFailure) {
+    return bodyFailingAfter(bytesBeforeFailure,
+        new ConnectionClosedException("Premature end of Content-Length delimited message body"));
+  }
+
+  /**
+   * A body that serves its bytes but fails on close, as Apache's stream does when the consumer
+   * stops before the end of the message and the remainder is drained.
+   */
+  @Nonnull
+  private static InputStream bodyFailingOnClose() {
+    return new InputStream() {
+
+      @Override
+      public int read() {
+        return 1;
+      }
+
+      @Override
+      public void close() throws IOException {
+        throw new ConnectionClosedException(
+            "Premature end of Content-Length delimited message body");
+      }
+    };
+  }
+
+  /**
+   * Copies the body through to a sink, so that a read failure surfaces from where it would in
+   * production: part way through the copy that {@code writeAll} performs.
+   */
+  private void writeAllConsumesTheBody() throws IOException {
+    when(fileHandle.writeAll(Mockito.any())).thenAnswer(invocation ->
+        IOUtils.copyLarge(invocation.getArgument(0, InputStream.class),
+            OutputStream.nullOutputStream()));
+  }
+
+  /**
+   * A response body that ends early is only discovered once it is being read, which is past the
+   * point where the HTTP client will retry for us. Exports of large resource types run to thousands
+   * of files, so without a retry here a single truncated body discards the whole export.
+   */
+  @Test
+  void testDownloadTaskRetriesAfterTruncatedBody() throws Exception {
+    when(httpClient.execute(Mockito.any())).thenReturn(httpResponse);
+    when(httpResponse.getStatusLine()).thenReturn(
+        new BasicStatusLine(new ProtocolVersion("http", 1, 1), 200, "OK"));
+    when(httpResponse.getEntity())
+        .thenReturn(new InputStreamEntity(truncatedBody(1), 3))
+        .thenReturn(new InputStreamEntity(new ByteArrayInputStream(new byte[]{1, 2, 3}), 3));
+    writeAllConsumesTheBody();
+
+    final UrlDownloadTemplate template = new UrlDownloadTemplate(httpClient, executorService,
+        DEFAULTS);
+    final long written = template.new UriDownloadTask(URI.create("http://foo.bar/file1"),
+        fileHandle).call();
+
+    assertEquals(3L, written);
+    verify(httpClient, Mockito.times(2)).execute(Mockito.any());
+  }
+
+  /**
+   * A truncation is not always discovered by a read. Apache's stream drains the rest of the message
+   * on close when the consumer stopped short of it, and raises the same failure from there, so the
+   * read side has to be recognised on close as well.
+   */
+  @Test
+  void testDownloadTaskRetriesAfterTruncationFoundOnClose() throws Exception {
+    when(httpClient.execute(Mockito.any())).thenReturn(httpResponse);
+    when(httpResponse.getStatusLine()).thenReturn(
+        new BasicStatusLine(new ProtocolVersion("http", 1, 1), 200, "OK"));
+    when(httpResponse.getEntity())
+        .thenReturn(new InputStreamEntity(bodyFailingOnClose(), 3))
+        .thenReturn(new InputStreamEntity(new ByteArrayInputStream(new byte[]{1, 2, 3}), 3));
+    // Stops short of the end of the message, leaving the remainder to be drained on close.
+    when(fileHandle.writeAll(Mockito.any())).thenAnswer(invocation -> {
+      invocation.getArgument(0, InputStream.class).read();
+      return 3L;
+    });
+
+    final UrlDownloadTemplate template = new UrlDownloadTemplate(httpClient, executorService,
+        DEFAULTS);
+    final long written = template.new UriDownloadTask(URI.create("http://foo.bar/file1"),
+        fileHandle).call();
+
+    assertEquals(3L, written);
+    verify(httpClient, Mockito.times(2)).execute(Mockito.any());
+  }
+
+  /**
+   * Retrying cannot mask a source that is genuinely broken, so the failure is still surfaced once
+   * the attempts are used up, and as the original exception rather than a wrapper.
+   */
+  @Test
+  void testDownloadTaskGivesUpAfterRepeatedFailures() throws Exception {
+    when(httpClient.execute(Mockito.any())).thenReturn(httpResponse);
+    when(httpResponse.getStatusLine()).thenReturn(
+        new BasicStatusLine(new ProtocolVersion("http", 1, 1), 200, "OK"));
+    when(httpResponse.getEntity()).thenAnswer(
+        invocation -> new InputStreamEntity(truncatedBody(1), 3));
+    writeAllConsumesTheBody();
+
+    final UrlDownloadTemplate template = new UrlDownloadTemplate(httpClient, executorService,
+        DEFAULTS);
+    final ConnectionClosedException ex = assertThrows(ConnectionClosedException.class,
+        () -> template.new UriDownloadTask(URI.create("http://foo.bar/file1"), fileHandle).call());
+
+    assertEquals("Premature end of Content-Length delimited message body", ex.getMessage());
+    verify(httpClient, Mockito.times(DEFAULTS.getMaxRetries() + 1)).execute(Mockito.any());
+  }
+
+  /**
+   * The number of retries is taken from the configuration, so that a caller can turn retrying off
+   * or widen it. Zero means the single attempt that was made before retrying existed.
+   */
+  @Test
+  void testDownloadTaskHonoursConfiguredRetries() throws Exception {
+    when(httpClient.execute(Mockito.any())).thenReturn(httpResponse);
+    when(httpResponse.getStatusLine()).thenReturn(
+        new BasicStatusLine(new ProtocolVersion("http", 1, 1), 200, "OK"));
+    when(httpResponse.getEntity()).thenAnswer(
+        invocation -> new InputStreamEntity(truncatedBody(1), 3));
+    writeAllConsumesTheBody();
+
+    final UrlDownloadTemplate template = new UrlDownloadTemplate(httpClient, executorService,
+        DownloadConfig.builder().maxRetries(0).build());
+    assertThrows(ConnectionClosedException.class,
+        () -> template.new UriDownloadTask(URI.create("http://foo.bar/file1"), fileHandle).call());
+
+    verify(httpClient, Mockito.times(1)).execute(Mockito.any());
+  }
+
+  /**
+   * A connection reset part way through is the same fault as a body that ends early, arriving as a
+   * reset rather than a close, and is equally past the point where the HTTP client will retry.
+   */
+  @Test
+  void testDownloadTaskRetriesAfterConnectionReset() throws Exception {
+    when(httpClient.execute(Mockito.any())).thenReturn(httpResponse);
+    when(httpResponse.getStatusLine()).thenReturn(
+        new BasicStatusLine(new ProtocolVersion("http", 1, 1), 200, "OK"));
+    when(httpResponse.getEntity())
+        .thenReturn(new InputStreamEntity(
+            bodyFailingAfter(1, new SocketException("Connection reset")), 3))
+        .thenReturn(new InputStreamEntity(new ByteArrayInputStream(new byte[]{1, 2, 3}), 3));
+    writeAllConsumesTheBody();
+
+    final UrlDownloadTemplate template = new UrlDownloadTemplate(httpClient, executorService,
+        DEFAULTS);
+    final long written = template.new UriDownloadTask(URI.create("http://foo.bar/file1"),
+        fileHandle).call();
+
+    assertEquals(3L, written);
+    verify(httpClient, Mockito.times(2)).execute(Mockito.any());
+  }
+
+  /**
+   * Retrying is confined to a transfer that was cut short, which is recognised by the type of the
+   * failure. Any other way of reading the body failing is not known to be transient, so repeating
+   * the transfer for it is not assumed to help.
+   */
+  @Test
+  void testDownloadTaskDoesNotRetryOtherReadFailures() throws Exception {
+    when(httpClient.execute(Mockito.any())).thenReturn(httpResponse);
+    when(httpResponse.getStatusLine()).thenReturn(
+        new BasicStatusLine(new ProtocolVersion("http", 1, 1), 200, "OK"));
+    when(httpResponse.getEntity()).thenReturn(new InputStreamEntity(
+        bodyFailingAfter(1, new IOException("Malformed response")), 3));
+    writeAllConsumesTheBody();
+
+    final UrlDownloadTemplate template = new UrlDownloadTemplate(httpClient, executorService,
+        DEFAULTS);
+    final IOException ex = assertThrows(IOException.class,
+        () -> template.new UriDownloadTask(URI.create("http://foo.bar/file1"), fileHandle).call());
+
+    assertEquals("Malformed response", ex.getMessage());
+    verify(httpClient, Mockito.times(1)).execute(Mockito.any());
+  }
+
+  /**
+   * A destination that cannot be written to is not a broken transfer. Fetching the body again
+   * cannot fix a full disk or a rejected write, so the transfer is not repeated for it.
+   */
+  @Test
+  void testDownloadTaskDoesNotRetryDestinationFailure() throws Exception {
+    when(httpClient.execute(Mockito.any())).thenReturn(httpResponse);
+    when(httpResponse.getStatusLine()).thenReturn(
+        new BasicStatusLine(new ProtocolVersion("http", 1, 1), 200, "OK"));
+    when(httpResponse.getEntity()).thenReturn(
+        new InputStreamEntity(new ByteArrayInputStream(new byte[]{1, 2, 3}), 3));
+    when(fileHandle.writeAll(Mockito.any()))
+        .thenThrow(new IOException("No space left on device"));
+
+    final UrlDownloadTemplate template = new UrlDownloadTemplate(httpClient, executorService,
+        DEFAULTS);
+    final IOException ex = assertThrows(IOException.class,
+        () -> template.new UriDownloadTask(URI.create("http://foo.bar/file1"), fileHandle).call());
+
+    assertEquals("No space left on device", ex.getMessage());
+    verify(httpClient, Mockito.times(1)).execute(Mockito.any());
+  }
+
+  /**
+   * A rejected request is a decision by the server rather than a broken transfer, so repeating it
+   * only adds load.
+   */
+  @Test
+  void testDownloadTaskDoesNotRetryHttpError() throws Exception {
+    when(httpClient.execute(Mockito.any())).thenReturn(httpResponse);
+    when(httpResponse.getStatusLine()).thenReturn(
+        new BasicStatusLine(new ProtocolVersion("http", 1, 1), 403, "Forbidden"));
+
+    final UrlDownloadTemplate template = new UrlDownloadTemplate(httpClient, executorService,
+        DEFAULTS);
+    assertThrows(HttpError.class, () -> template.new UriDownloadTask(
+        URI.create("http://foo.bar/file1"), fileHandle).call());
+
+    verify(httpClient, Mockito.times(1)).execute(Mockito.any());
   }
 }

--- a/src/test/java/au/csiro/fhir/export/download/UrlDownloadTemplateTest.java
+++ b/src/test/java/au/csiro/fhir/export/download/UrlDownloadTemplateTest.java
@@ -81,6 +81,13 @@ class UrlDownloadTemplateTest {
    */
   private static final DownloadConfig DEFAULTS = DownloadConfig.builder().build();
 
+  /**
+   * Retries are exercised without waiting out the real delay.
+   */
+  private static final DownloadConfig NO_DELAY = DownloadConfig.builder()
+      .maxRetryDelay(Duration.ZERO)
+      .build();
+
   @Test
   void testDownloadsAllUrlsSuccessfully() {
     final UrlDownloadTemplate template = new UrlDownloadTemplate(httpClient, executorService,
@@ -253,7 +260,7 @@ class UrlDownloadTemplateTest {
     writeAllConsumesTheBody();
 
     final UrlDownloadTemplate template = new UrlDownloadTemplate(httpClient, executorService,
-        DEFAULTS);
+        NO_DELAY);
     final long written = template.new UriDownloadTask(URI.create("http://foo.bar/file1"),
         fileHandle).call();
 
@@ -281,7 +288,7 @@ class UrlDownloadTemplateTest {
     });
 
     final UrlDownloadTemplate template = new UrlDownloadTemplate(httpClient, executorService,
-        DEFAULTS);
+        NO_DELAY);
     final long written = template.new UriDownloadTask(URI.create("http://foo.bar/file1"),
         fileHandle).call();
 
@@ -303,12 +310,12 @@ class UrlDownloadTemplateTest {
     writeAllConsumesTheBody();
 
     final UrlDownloadTemplate template = new UrlDownloadTemplate(httpClient, executorService,
-        DEFAULTS);
+        NO_DELAY);
     final ConnectionClosedException ex = assertThrows(ConnectionClosedException.class,
         () -> template.new UriDownloadTask(URI.create("http://foo.bar/file1"), fileHandle).call());
 
     assertEquals("Premature end of Content-Length delimited message body", ex.getMessage());
-    verify(httpClient, Mockito.times(DEFAULTS.getMaxRetries() + 1)).execute(Mockito.any());
+    verify(httpClient, Mockito.times(NO_DELAY.getMaxRetries() + 1)).execute(Mockito.any());
   }
 
   /**
@@ -325,11 +332,45 @@ class UrlDownloadTemplateTest {
     writeAllConsumesTheBody();
 
     final UrlDownloadTemplate template = new UrlDownloadTemplate(httpClient, executorService,
-        DownloadConfig.builder().maxRetries(0).build());
+        DownloadConfig.builder().maxRetries(0).maxRetryDelay(Duration.ZERO).build());
     assertThrows(ConnectionClosedException.class,
         () -> template.new UriDownloadTask(URI.create("http://foo.bar/file1"), fileHandle).call());
 
     verify(httpClient, Mockito.times(1)).execute(Mockito.any());
+  }
+
+  /**
+   * A waiting task holds one of the download threads, so the wait is bounded by the configured
+   * maximum however many attempts are made. Each delay is drawn at random from that window, so the
+   * bound is all that can be asserted - an individual delay may be anything up to it.
+   */
+  @Test
+  void testDownloadTaskKeepsRetryDelaysWithinTheConfiguredBound() throws Exception {
+    final Duration maxRetryDelay = Duration.ofMillis(200);
+    when(httpClient.execute(Mockito.any())).thenReturn(httpResponse);
+    when(httpResponse.getStatusLine()).thenReturn(
+        new BasicStatusLine(new ProtocolVersion("http", 1, 1), 200, "OK"));
+    when(httpResponse.getEntity()).thenAnswer(
+        invocation -> new InputStreamEntity(truncatedBody(1), 3));
+    writeAllConsumesTheBody();
+
+    final DownloadConfig config = DownloadConfig.builder()
+        .maxRetries(2)
+        .maxRetryDelay(maxRetryDelay)
+        .build();
+    final UrlDownloadTemplate template = new UrlDownloadTemplate(httpClient, executorService,
+        config);
+
+    final long startedAt = System.nanoTime();
+    assertThrows(ConnectionClosedException.class,
+        () -> template.new UriDownloadTask(URI.create("http://foo.bar/file1"), fileHandle).call());
+    final Duration elapsed = Duration.ofNanos(System.nanoTime() - startedAt);
+
+    // One delay precedes each retry, and none of them may exceed the maximum.
+    final Duration longestPossibleWait = maxRetryDelay.multipliedBy(config.getMaxRetries());
+    assertTrue(elapsed.compareTo(longestPossibleWait.plusSeconds(1)) < 0,
+        "Retries took " + elapsed + ", which exceeds the bound of " + longestPossibleWait);
+    verify(httpClient, Mockito.times(3)).execute(Mockito.any());
   }
 
   /**
@@ -348,7 +389,7 @@ class UrlDownloadTemplateTest {
     writeAllConsumesTheBody();
 
     final UrlDownloadTemplate template = new UrlDownloadTemplate(httpClient, executorService,
-        DEFAULTS);
+        NO_DELAY);
     final long written = template.new UriDownloadTask(URI.create("http://foo.bar/file1"),
         fileHandle).call();
 
@@ -371,7 +412,7 @@ class UrlDownloadTemplateTest {
     writeAllConsumesTheBody();
 
     final UrlDownloadTemplate template = new UrlDownloadTemplate(httpClient, executorService,
-        DEFAULTS);
+        NO_DELAY);
     final IOException ex = assertThrows(IOException.class,
         () -> template.new UriDownloadTask(URI.create("http://foo.bar/file1"), fileHandle).call());
 
@@ -394,7 +435,7 @@ class UrlDownloadTemplateTest {
         .thenThrow(new IOException("No space left on device"));
 
     final UrlDownloadTemplate template = new UrlDownloadTemplate(httpClient, executorService,
-        DEFAULTS);
+        NO_DELAY);
     final IOException ex = assertThrows(IOException.class,
         () -> template.new UriDownloadTask(URI.create("http://foo.bar/file1"), fileHandle).call());
 
@@ -413,7 +454,7 @@ class UrlDownloadTemplateTest {
         new BasicStatusLine(new ProtocolVersion("http", 1, 1), 403, "Forbidden"));
 
     final UrlDownloadTemplate template = new UrlDownloadTemplate(httpClient, executorService,
-        DEFAULTS);
+        NO_DELAY);
     assertThrows(HttpError.class, () -> template.new UriDownloadTask(
         URI.create("http://foo.bar/file1"), fileHandle).call());
 

--- a/src/test/java/au/csiro/fhir/export/ws/BulkExportResponseTest.java
+++ b/src/test/java/au/csiro/fhir/export/ws/BulkExportResponseTest.java
@@ -1,0 +1,217 @@
+/*
+ * Copyright 2023 Commonwealth Scientific and Industrial Research
+ * Organisation (CSIRO) ABN 41 687 119 230.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package au.csiro.fhir.export.ws;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import au.csiro.fhir.export.BulkExportException.ProtocolError;
+import au.csiro.fhir.export.ws.BulkExportResponse.FileItem;
+import au.csiro.fhir.model.FhirJsonSupport;
+import java.time.Instant;
+import java.util.Collections;
+import java.util.List;
+import javax.annotation.Nonnull;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+/**
+ * Tests for the validation of {@link BulkExportResponse}.
+ */
+public class BulkExportResponseTest {
+
+  @Nonnull
+  private static BulkExportResponse responseWithType(@Nonnull final String type) {
+    return responseWith(new FileItem(type, "https://foo.bar/1", 10));
+  }
+
+  @Nonnull
+  private static BulkExportResponse responseWith(@Nonnull final FileItem... items) {
+    return BulkExportResponse.builder()
+        .transactionTime(Instant.now())
+        .request("fake-request")
+        .output(List.of(items))
+        .deleted(Collections.emptyList())
+        .error(Collections.emptyList())
+        .build();
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"Patient", "Condition", "OperationOutcome", "CustomResource", "Base64X"})
+  void testAcceptsValidResourceTypes(@Nonnull final String type) {
+    responseWithType(type).validate();
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {
+      "../../../secret",           // POSIX traversal
+      "..\\..\\secret",            // Windows traversal
+      "/etc/passwd",               // absolute path
+      "C:evil",                    // Windows drive relative
+      "..%2f..%2fsecret",          // url encoded traversal
+      "%2e%2e%2fsecret",           // fully url encoded traversal
+      "..",                        // bare parent reference
+      ".",                         // bare current reference
+      "",                          // empty
+      " Patient",                  // leading space
+      "Patient ",                  // trailing space
+      "Pati\0ent",                 // embedded NUL
+      "Patiént",              // non ascii
+      "9Patient",                  // leading digit
+      "Patient.0000"               // embedded dot
+  })
+  void testRejectsTypeThatIsNotAResourceTypeName(@Nonnull final String type) {
+    final ProtocolError ex = assertThrows(ProtocolError.class,
+        () -> responseWithType(type).validate());
+    assertEquals("Manifest 'type' is not a valid FHIR resource type name: " + type,
+        ex.getMessage());
+  }
+
+  @Test
+  void testRejectsTypeThatIsTooLong() {
+    final String type = "P".repeat(65);
+    final ProtocolError ex = assertThrows(ProtocolError.class,
+        () -> responseWithType(type).validate());
+    assertEquals("Manifest 'type' is not a valid FHIR resource type name: " + type,
+        ex.getMessage());
+  }
+
+  @Test
+  void testRejectsInvalidTypeAmongstValidOnes() {
+    final BulkExportResponse response = responseWith(
+        new FileItem("Patient", "https://foo.bar/1", 10),
+        new FileItem("../../../secret", "https://foo.bar/2", 10));
+
+    final ProtocolError ex = assertThrows(ProtocolError.class, response::validate);
+    assertEquals("Manifest 'type' is not a valid FHIR resource type name: ../../../secret",
+        ex.getMessage());
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"file:///etc/passwd", "jar:file:///tmp/x.jar!/y", "data:text/plain,x",
+      "ftp://foo.bar/1", "/relative/no/scheme"})
+  void testRejectsUrlWithUnsupportedScheme(@Nonnull final String url) {
+    final BulkExportResponse response = responseWith(new FileItem("Patient", url, 10));
+
+    final ProtocolError ex = assertThrows(ProtocolError.class, response::validate);
+    assertEquals("Manifest 'url' has an unsupported scheme: " + url, ex.getMessage());
+  }
+
+  @Test
+  void testRejectsUrlThatIsNotAValidUri() {
+    final BulkExportResponse response = responseWith(
+        new FileItem("Patient", "https://foo.bar/has a space", 10));
+
+    final ProtocolError ex = assertThrows(ProtocolError.class, response::validate);
+    assertEquals("Manifest 'url' is not a valid URI: https://foo.bar/has a space",
+        ex.getMessage());
+  }
+
+  @Test
+  void testAcceptsHttpAndHttpsUrls() {
+    responseWith(
+        new FileItem("Patient", "http://foo.bar/1", 10),
+        new FileItem("Condition", "HTTPS://foo.bar/2", 10)
+    ).validate();
+  }
+
+  @Test
+  void testRejectsManifestWithMissingTransactionTime() {
+    // Gson populates fields reflectively, so a manifest omitting a value leaves it null despite
+    // the @Nonnull annotation. Parsing rather than building is what reproduces this.
+    final BulkExportResponse response = parse("{"
+        + "\"request\": \"fake-request\","
+        + "\"output\": [{\"type\": \"Patient\", \"url\": \"https://foo.bar/1\", \"count\": 1}]"
+        + "}");
+
+    final ProtocolError ex = assertThrows(ProtocolError.class, response::validate);
+    assertEquals("Manifest is missing 'transactionTime'", ex.getMessage());
+  }
+
+  @Test
+  void testRejectsManifestWithNullOutput() {
+    final BulkExportResponse response = parse("{"
+        + "\"transactionTime\": \"2023-01-01T00:00:00.000Z\","
+        + "\"request\": \"fake-request\","
+        + "\"output\": null"
+        + "}");
+
+    final ProtocolError ex = assertThrows(ProtocolError.class, response::validate);
+    assertEquals("Manifest is missing 'output'", ex.getMessage());
+  }
+
+  @Test
+  void testRejectsParsedManifestWithTraversalInType() {
+    final BulkExportResponse response = parse("{"
+        + "\"transactionTime\": \"2023-01-01T00:00:00.000Z\","
+        + "\"request\": \"fake-request\","
+        + "\"output\": [{\"type\": \"../../../secret\", \"url\": \"https://foo.bar/1\","
+        + " \"count\": 1}]"
+        + "}");
+
+    final ProtocolError ex = assertThrows(ProtocolError.class, response::validate);
+    assertEquals("Manifest 'type' is not a valid FHIR resource type name: ../../../secret",
+        ex.getMessage());
+  }
+
+  @Test
+  void testRejectsParsedManifestWithMissingType() {
+    final BulkExportResponse response = parse("{"
+        + "\"transactionTime\": \"2023-01-01T00:00:00.000Z\","
+        + "\"request\": \"fake-request\","
+        + "\"output\": [{\"url\": \"https://foo.bar/1\", \"count\": 1}]"
+        + "}");
+
+    final ProtocolError ex = assertThrows(ProtocolError.class, response::validate);
+    assertEquals("Manifest 'type' is not a valid FHIR resource type name: null", ex.getMessage());
+  }
+
+  @Test
+  void testRejectsParsedManifestWithMissingUrl() {
+    final BulkExportResponse response = parse("{"
+        + "\"transactionTime\": \"2023-01-01T00:00:00.000Z\","
+        + "\"request\": \"fake-request\","
+        + "\"output\": [{\"type\": \"Patient\", \"count\": 1}]"
+        + "}");
+
+    final ProtocolError ex = assertThrows(ProtocolError.class, response::validate);
+    assertEquals("Manifest 'url' is missing for type: Patient", ex.getMessage());
+  }
+
+  @Test
+  void testIgnoresValuesThatAreNotConsumed() {
+    // The client does not read 'deleted', 'error' or 'count', so odd values there must not cause
+    // an otherwise usable manifest to be rejected.
+    final BulkExportResponse response = parse("{"
+        + "\"transactionTime\": \"2023-01-01T00:00:00.000Z\","
+        + "\"request\": \"fake-request\","
+        + "\"output\": [{\"type\": \"Patient\", \"url\": \"https://foo.bar/1\", \"count\": -1}],"
+        + "\"deleted\": [{\"type\": \"../../../secret\", \"url\": \"file:///x\", \"count\": 1}],"
+        + "\"error\": [{\"type\": \"../../../secret\", \"url\": \"file:///x\", \"count\": 1}]"
+        + "}");
+
+    response.validate();
+  }
+
+  @Nonnull
+  private static BulkExportResponse parse(@Nonnull final String json) {
+    return FhirJsonSupport.fromJson(json, BulkExportResponse.class)
+        .orElseThrow(() -> new AssertionError("Failed to parse: " + json));
+  }
+}

--- a/src/test/java/au/csiro/fhir/export/ws/BulkExportResponseTest.java
+++ b/src/test/java/au/csiro/fhir/export/ws/BulkExportResponseTest.java
@@ -171,6 +171,18 @@ public class BulkExportResponseTest {
   }
 
   @Test
+  void testRejectsParsedManifestWithNullEntryInOutput() {
+    final BulkExportResponse response = parse("{"
+        + "\"transactionTime\": \"2023-01-01T00:00:00.000Z\","
+        + "\"request\": \"fake-request\","
+        + "\"output\": [{\"type\": \"Patient\", \"url\": \"https://foo.bar/1\"}, null]"
+        + "}");
+
+    final ProtocolError ex = assertThrows(ProtocolError.class, response::validate);
+    assertEquals("Manifest 'output' contains a null entry", ex.getMessage());
+  }
+
+  @Test
   void testRejectsParsedManifestWithMissingType() {
     final BulkExportResponse response = parse("{"
         + "\"transactionTime\": \"2023-01-01T00:00:00.000Z\","

--- a/src/test/java/au/csiro/filestore/AbstractFileStoreFactoryTest.java
+++ b/src/test/java/au/csiro/filestore/AbstractFileStoreFactoryTest.java
@@ -81,6 +81,24 @@ public abstract class AbstractFileStoreFactoryTest {
     assertEquals("Hello, world!", FileUtils.readFileToString(file, StandardCharsets.UTF_8));
   }
 
+  /**
+   * A download that is retried writes the file again from the start, so an implementation that
+   * appended, or that left the tail of a longer earlier write in place, would silently corrupt the
+   * output. The second write here is the shorter of the two, so any residue of the first shows up.
+   */
+  @Test
+  void testWriteAllReplacesExistingContent() throws IOException {
+    final File file = testRootDir.resolve("file").toFile();
+    final FileHandle handle = fileStore.get(file.getPath());
+    handle.writeAll(IOUtils.toInputStream("A partial write from a failed attempt",
+        StandardCharsets.UTF_8));
+    final long written = handle.writeAll(
+        IOUtils.toInputStream("Hello, world!", StandardCharsets.UTF_8));
+
+    assertEquals("Hello, world!", FileUtils.readFileToString(file, StandardCharsets.UTF_8));
+    assertEquals("Hello, world!".length(), written);
+  }
+
   @Test
   void testToUriWorks() {
     Assertions.assertEquals("/foo/bar", FileHandle.ofLocal("/foo/bar").getLocation());

--- a/src/test/java/au/csiro/filestore/LocalFileStoreTest.java
+++ b/src/test/java/au/csiro/filestore/LocalFileStoreTest.java
@@ -18,14 +18,18 @@
 package au.csiro.filestore;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.FileAlreadyExistsException;
 import java.nio.file.FileSystemException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import javax.annotation.Nonnull;
 import org.apache.commons.io.IOUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -46,36 +50,74 @@ public class LocalFileStoreTest extends AbstractFileStoreFactoryTest {
   }
 
   @Test
-  void writeAllRefusesToFollowSymlinkAtDestination() throws IOException {
-    // A pre-placed symlink at the destination must not be followed; otherwise an attacker who
-    // could plant a symlink in the staging directory could redirect downloads to arbitrary files.
-    final Path target = testRootDir.resolve("target.txt");
-    Files.writeString(target, "original");
-    final Path link = testRootDir.resolve("link.txt");
-    try {
-      Files.createSymbolicLink(link, target);
-    } catch (final UnsupportedOperationException | FileSystemException e) {
-      // Skip on platforms that disallow symlink creation (e.g. Windows without privilege).
-      assumeTrue(false, "Symbolic links are not supported in this environment.");
-    }
+  void testWriteAllRefusesToOverwriteExistingFile() throws IOException {
+    final Path existing = testRootDir.resolve("existing.txt");
+    Files.writeString(existing, "original");
 
-    assertThrows(IOException.class, () -> fileStore.get(link.toString())
+    assertThrows(FileAlreadyExistsException.class, () -> fileStore.get(existing.toString())
         .writeAll(IOUtils.toInputStream("payload", StandardCharsets.UTF_8)));
 
-    // The symlink target must remain unchanged.
+    assertEquals("original", Files.readString(existing));
+  }
+
+  @Test
+  void testWriteAllRefusesToWriteOverSymlinkAtDestination() throws IOException {
+    // A symlink already present under the name of a file about to be written is an existing entry
+    // as far as CREATE_NEW is concerned, so it is refused rather than followed to its target.
+    final Path target = testRootDir.resolve("target.txt");
+    Files.writeString(target, "original");
+    final Path link = createSymbolicLink(testRootDir.resolve("link.txt"), target);
+
+    assertThrows(FileAlreadyExistsException.class, () -> fileStore.get(link.toString())
+        .writeAll(IOUtils.toInputStream("payload", StandardCharsets.UTF_8)));
+
     assertEquals("original", Files.readString(target));
   }
 
   @Test
-  void writeAllRefusesToOverwriteExistingFile() throws IOException {
-    // CREATE_NEW prevents accidental or malicious overwrites of existing files in the staging
-    // directory.
-    final Path existing = testRootDir.resolve("existing.txt");
-    Files.writeString(existing, "original");
+  void testWriteAllWorksThroughSymlinkedParentDirectory() throws IOException {
+    // Reaching other storage through a symlinked directory is a legitimate layout, so symlinks
+    // above the file being written must still be followed.
+    final Path storageDir = Files.createDirectory(testRootDir.resolve("storage"));
+    final Path linkedDir = createSymbolicLink(testRootDir.resolve("linked"), storageDir);
 
-    assertThrows(IOException.class, () -> fileStore.get(existing.toString())
-        .writeAll(IOUtils.toInputStream("payload", StandardCharsets.UTF_8)));
+    fileStore.get(linkedDir.resolve("Patient.0000.ndjson").toString())
+        .writeAll(IOUtils.toInputStream("payload", StandardCharsets.UTF_8));
 
-    assertEquals("original", Files.readString(existing));
+    assertEquals("payload", Files.readString(storageDir.resolve("Patient.0000.ndjson")));
+  }
+
+  @Test
+  void testMkdirsSucceedsWhenDirectoryAlreadyExists() throws IOException {
+    // File.mkdirs() returns false for an existing directory, which must not be reported as a
+    // failure to create it.
+    final Path existing = Files.createDirectory(testRootDir.resolve("existing-dir"));
+
+    assertTrue(fileStore.get(existing.toString()).mkdirs());
+  }
+
+  @Test
+  void testMkdirsFailsWhenDirectoryCannotBeCreated() throws IOException {
+    // A dangling symlink is neither creatable as a directory nor already one, so mkdirs() has to
+    // report the failure rather than let the export proceed against a directory that is not there.
+    final Path dangling = createSymbolicLink(testRootDir.resolve("dangling"),
+        testRootDir.resolve("absent"));
+
+    assertFalse(fileStore.get(dangling.toString()).mkdirs());
+  }
+
+  /**
+   * Creates a symbolic link, skipping the calling test on platforms that do not permit it.
+   */
+  @Nonnull
+  private static Path createSymbolicLink(@Nonnull final Path link, @Nonnull final Path target)
+      throws IOException {
+    try {
+      return Files.createSymbolicLink(link, target);
+    } catch (final UnsupportedOperationException | FileSystemException ex) {
+      // Skip on platforms that disallow symlink creation (e.g. Windows without privilege).
+      assumeTrue(false, "Symbolic links are not supported in this environment.");
+      throw new AssertionError("unreachable");
+    }
   }
 }

--- a/src/test/java/au/csiro/filestore/LocalFileStoreTest.java
+++ b/src/test/java/au/csiro/filestore/LocalFileStoreTest.java
@@ -13,12 +13,24 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
+ * @author John Grimes
  */
 
 package au.csiro.filestore;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.FileSystemException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.apache.commons.io.IOUtils;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests for {@link LocalFileStore}.
@@ -30,5 +42,39 @@ public class LocalFileStoreTest extends AbstractFileStoreFactoryTest {
   @BeforeEach
   void setUp() throws IOException {
     fileStore = fileStoreFactory.createFileStore(testRootDir.toString());
+  }
+
+  @Test
+  void writeAllRefusesToFollowSymlinkAtDestination() throws IOException {
+    // A pre-placed symlink at the destination must not be followed; otherwise an attacker who
+    // could plant a symlink in the staging directory could redirect downloads to arbitrary files.
+    final Path target = testRootDir.resolve("target.txt");
+    Files.writeString(target, "original");
+    final Path link = testRootDir.resolve("link.txt");
+    try {
+      Files.createSymbolicLink(link, target);
+    } catch (final UnsupportedOperationException | FileSystemException e) {
+      // Skip on platforms that disallow symlink creation (e.g. Windows without privilege).
+      assumeTrue(false, "Symbolic links are not supported in this environment.");
+    }
+
+    assertThrows(IOException.class, () -> fileStore.get(link.toString())
+        .writeAll(IOUtils.toInputStream("payload", StandardCharsets.UTF_8)));
+
+    // The symlink target must remain unchanged.
+    assertEquals("original", Files.readString(target));
+  }
+
+  @Test
+  void writeAllRefusesToOverwriteExistingFile() throws IOException {
+    // CREATE_NEW prevents accidental or malicious overwrites of existing files in the staging
+    // directory.
+    final Path existing = testRootDir.resolve("existing.txt");
+    Files.writeString(existing, "original");
+
+    assertThrows(IOException.class, () -> fileStore.get(existing.toString())
+        .writeAll(IOUtils.toInputStream("payload", StandardCharsets.UTF_8)));
+
+    assertEquals("original", Files.readString(existing));
   }
 }

--- a/src/test/java/au/csiro/filestore/LocalFileStoreTest.java
+++ b/src/test/java/au/csiro/filestore/LocalFileStoreTest.java
@@ -13,8 +13,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- * @author John Grimes
  */
 
 package au.csiro.filestore;
@@ -34,6 +32,9 @@ import org.junit.jupiter.api.Test;
 
 /**
  * Tests for {@link LocalFileStore}.
+ *
+ * @author Piotr Szul
+ * @author John Grimes
  */
 public class LocalFileStoreTest extends AbstractFileStoreFactoryTest {
 

--- a/src/test/java/au/csiro/filestore/hdfs/HdfsFileStoreFactoryTest.java
+++ b/src/test/java/au/csiro/filestore/hdfs/HdfsFileStoreFactoryTest.java
@@ -77,4 +77,17 @@ public class HdfsFileStoreFactoryTest extends AbstractFileStoreFactoryTest {
 
     verify(borrowed, never()).close();
   }
+
+  /**
+   * A store built over a caller-supplied filesystem writes through that instance and leaves it
+   * open, so that the caller can keep using it once the export has finished.
+   */
+  @Test
+  void testFactoryForSuppliedFileSystemLeavesItOpen() throws IOException {
+    final FileSystem supplied = mock(FileSystem.class);
+
+    HdfsFileStoreFactory.forFileSystem(supplied).createFileStore(testRootDir.toString()).close();
+
+    verify(supplied, never()).close();
+  }
 }

--- a/src/test/java/au/csiro/filestore/hdfs/HdfsFileStoreFactoryTest.java
+++ b/src/test/java/au/csiro/filestore/hdfs/HdfsFileStoreFactoryTest.java
@@ -17,10 +17,20 @@
 
 package au.csiro.filestore.hdfs;
 
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
 import au.csiro.filestore.AbstractFileStoreFactoryTest;
+import au.csiro.filestore.FileStore;
 import au.csiro.filestore.FileStoreFactory;
 import java.io.IOException;
+import java.net.URI;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests for {@link HdfsFileStoreFactory}.
@@ -32,5 +42,39 @@ public class HdfsFileStoreFactoryTest extends AbstractFileStoreFactoryTest {
   @BeforeEach
   void setUp() throws IOException {
     fileStore = fileStoreFactory.createFileStore(testRootDir.toString());
+  }
+
+  /**
+   * Closing a store must not disturb the filesystem instance that the host application shares
+   * through the Hadoop filesystem cache. Closing a cached instance evicts it from the cache, so the
+   * application's reference is left closed and a later lookup returns a different instance. For
+   * schemes that guard against use after close, such as S3A, that leaves the application unable to
+   * reach the scheme at all.
+   */
+  @Test
+  void testClosingStoreLeavesTheCachedFileSystemInPlace() throws IOException {
+    final URI location = URI.create(testRootDir.toString());
+    final FileSystem cached = FileSystem.get(location, new Configuration());
+
+    try (final FileStore store = fileStoreFactory.createFileStore(testRootDir.toString())) {
+      store.get(testRootDir.resolve("some-directory").toString()).mkdirs();
+    }
+
+    // The cached instance must still be the one the application gets, and must not have been
+    // evicted by the store closing it.
+    assertSame(cached, FileSystem.get(location, new Configuration()));
+  }
+
+  /**
+   * The filesystem is always borrowed, whether it came from the caller or from the Hadoop cache, so
+   * closing a store must never close it.
+   */
+  @Test
+  void testClosingStoreDoesNotCloseTheFileSystem() throws IOException {
+    final FileSystem borrowed = mock(FileSystem.class);
+
+    new HdfsFileStoreFactory.HdfsFileStore(borrowed).close();
+
+    verify(borrowed, never()).close();
   }
 }


### PR DESCRIPTION
Aggregates three PRs into the 1.1.0 release, per the short-lived-branch process in `CONTRIBUTING.md`.

## Included

- #11 — Validate the export manifest to prevent path traversal in download destinations (patch-level: security fix)
- #13 — Stop closing a shared Hadoop filesystem; adds public `forFileSystem` (minor: new public API)
- #16 — Retry a download whose transfer is cut short; adds public `DownloadConfig` (minor: new public API)

Combined, these justify a **minor** version bump: 1.1.0.

## Notable interaction fixed while combining #11 and #16

`LocalFileStore.writeAll` (from #11) opened destinations with `CREATE_NEW`, refusing to write over anything already there — including a partial file left by #16's retry logic, which needs to reopen the same destination and overwrite it after a truncated attempt. Fixed by switching to `CREATE, TRUNCATE_EXISTING` combined with `LinkOption.NOFOLLOW_LINKS`, which still refuses to write through a symlink at the destination (verified to guard only the final path component, not symlinked parent directories) while allowing a regular file — including our own partial write — to be replaced. Full detail and rationale is on #11.

## Version

`pom.xml` bumped to `1.1.0-SNAPSHOT` on this branch. Merging into `main` will need the usual release steps (set release version, tag, then bump `main` back to the next `-SNAPSHOT`) per `RELEASE_CHECKLIST.md`.

## Testing

Full suite passes on this branch: 169 tests, 0 failures, 0 errors, 0 skipped — including #11's and #16's tests running together for the first time.
