### PR TITLE
Fix dependency vulnerabilities flagged by Dependabot

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -93,7 +93,7 @@
     <bulkExport.guavaVersion>32.1.3-jre</bulkExport.guavaVersion>
     <bulkExport.slf4jVersion>1.7.36</bulkExport.slf4jVersion>
     <bulkExport.httpclientVersion>4.5.14</bulkExport.httpclientVersion>
-    <bulkExport.logbackVersion>1.2.11</bulkExport.logbackVersion>
+    <bulkExport.logbackVersion>1.5.34</bulkExport.logbackVersion>
     <bulkExport.mockitoVersion>4.8.1</bulkExport.mockitoVersion>
     <bulkExport.jupyterVersion>5.9.1</bulkExport.jupyterVersion>
     <bulkExport.surefireVersion>3.1.2</bulkExport.surefireVersion>
@@ -246,7 +246,7 @@
       <dependency>
         <groupId>commons-io</groupId>
         <artifactId>commons-io</artifactId>
-        <version>2.13.0</version>
+        <version>2.14.0</version>
       </dependency>
       <dependency>
         <groupId>org.apache.httpcomponents</groupId>
@@ -285,7 +285,7 @@
       <dependency>
         <groupId>org.json</groupId>
         <artifactId>json</artifactId>
-        <version>20230618</version>
+        <version>20231013</version>
       </dependency>
       <dependency>
         <groupId>org.skyscreamer</groupId>
@@ -302,7 +302,7 @@
       <dependency>
         <groupId>com.github.tomakehurst</groupId>
         <artifactId>wiremock-jre8-standalone</artifactId>
-        <version>2.35.0</version>
+        <version>2.35.1</version>
         <scope>test</scope>
       </dependency>
       <dependency>


### PR DESCRIPTION
## Summary
- Bump `ch.qos.logback` from 1.2.11 to 1.5.34 — clears 3 HIGH, 2 MEDIUM, 3 LOW alerts (serialization/RCE-adjacent issues, EL injection, SSRF, arbitrary code execution via file processing)
- Bump `commons-io` from 2.13.0 to 2.14.0 — clears 1 HIGH alert (DoS via `XmlStreamReader` on untrusted input)
- Bump `org.json:json` from 20230618 to 20231013 — clears 1 HIGH alert (DoS in JSON parsing)
- Bump `wiremock-jre8-standalone` from 2.35.0 to 2.35.1 (test scope) — clears 1 LOW alert (DNS rebinding bypass)

Versions chosen to at least match or exceed what `pathling` already pins for the same libraries, and to reach the first patched version for each open advisory.

## Test plan
- [x] `mvn test` passes locally under JDK 11
- [ ] CI (`verify.yml`) passes on JDK 11/17/21
- [ ] Confirm all 11 Dependabot alerts close after merge